### PR TITLE
Ouch - a prototype CouchDB/PouchDB driver for Go/GopherJS

### DIFF
--- a/graph/all/all.go
+++ b/graph/all/all.go
@@ -7,7 +7,7 @@ import (
 	_ "github.com/cayleygraph/cayley/graph/kv/leveldb"
 	_ "github.com/cayleygraph/cayley/graph/leveldb"
 	_ "github.com/cayleygraph/cayley/graph/memstore"
-	_ "github.com/cayleygraph/cayley/graph/mongo"
+	_ "github.com/cayleygraph/cayley/graph/nosql/mongo"
 	_ "github.com/cayleygraph/cayley/graph/sql/cockroach"
 	_ "github.com/cayleygraph/cayley/graph/sql/mysql"
 	_ "github.com/cayleygraph/cayley/graph/sql/postgres"

--- a/graph/all/all.go
+++ b/graph/all/all.go
@@ -7,6 +7,7 @@ import (
 	_ "github.com/cayleygraph/cayley/graph/kv/leveldb"
 	_ "github.com/cayleygraph/cayley/graph/leveldb"
 	_ "github.com/cayleygraph/cayley/graph/memstore"
+	_ "github.com/cayleygraph/cayley/graph/nosql/dynamo"
 	_ "github.com/cayleygraph/cayley/graph/nosql/mongo"
 	_ "github.com/cayleygraph/cayley/graph/sql/cockroach"
 	_ "github.com/cayleygraph/cayley/graph/sql/mysql"

--- a/graph/nosql/dynamo/dynamo.go
+++ b/graph/nosql/dynamo/dynamo.go
@@ -1,0 +1,649 @@
+package dynamo
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/cayleygraph/cayley/graph"
+	"github.com/cayleygraph/cayley/graph/nosql"
+	"github.com/pborman/uuid"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+)
+
+const Type = "dynamo"
+
+func init() {
+	nosql.Register(Type, nosql.Registration{
+		NewFunc:      Open,
+		InitFunc:     Create,
+		IsPersistent: true,
+	})
+}
+
+func newSession(access, secret, region string) (*session.Session, error) {
+	cred := credentials.NewStaticCredentials(access, secret, "")
+	return session.NewSession(&aws.Config{
+		Region:      aws.String(region),
+		Credentials: cred,
+	})
+}
+
+func newDB(addr string, opt graph.Options) (*DB, error) {
+	acc, _, _ := opt.StringKey("accessKey")
+	sec, _, _ := opt.StringKey("secretKey")
+	reg, _, _ := opt.StringKey("region")
+	sess, err := newSession(acc, sec, reg)
+	if err != nil {
+		return nil, err
+	}
+	if addr == "" {
+		addr = nosql.DefaultDBName
+	}
+	return &DB{pref: addr + "_", db: dynamodb.New(sess)}, nil
+}
+
+func Create(addr string, opt graph.Options) (nosql.Database, error) {
+	return newDB(addr, opt)
+}
+
+func Open(addr string, opt graph.Options) (nosql.Database, error) {
+	return newDB(addr, opt)
+}
+
+func convError(err error) error {
+	if e, ok := err.(awserr.Error); ok {
+		switch e.Code() {
+		case "ResourceNotFoundException":
+			return nosql.ErrNotFound
+			//case "ConditionalCheckFailedException":
+		}
+	}
+	return err
+}
+
+type DB struct {
+	pref string
+	db   *dynamodb.DynamoDB
+}
+
+func (db *DB) col(name string) *string {
+	return aws.String(db.pref + name)
+}
+func (db *DB) Close() error {
+	return nil
+}
+
+func (db *DB) waitTable(ctx context.Context, name *string) error {
+	for {
+		resp, err := db.db.DescribeTable(&dynamodb.DescribeTableInput{
+			TableName: name,
+		})
+		if err != nil {
+			return err
+		}
+		switch *resp.Table.TableStatus {
+		case "ACTIVE":
+			return nil
+		case "DELETING":
+			return errors.New("table is being deleted")
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(time.Second):
+		}
+	}
+}
+
+func (db *DB) EnsureIndex(col string, indexes ...nosql.Index) error {
+	tbl := db.col(col)
+	_, err := db.db.CreateTable(&dynamodb.CreateTableInput{
+		TableName: tbl,
+		AttributeDefinitions: []*dynamodb.AttributeDefinition{
+			{
+				AttributeName: aws.String(nosql.IDField),
+				AttributeType: aws.String("S"),
+			},
+		},
+		KeySchema: []*dynamodb.KeySchemaElement{
+			{
+				AttributeName: aws.String(nosql.IDField),
+				KeyType:       aws.String("HASH"),
+			},
+		},
+		ProvisionedThroughput: &dynamodb.ProvisionedThroughput{
+			ReadCapacityUnits:  aws.Int64(5),
+			WriteCapacityUnits: aws.Int64(5),
+		},
+	})
+	if e, ok := err.(awserr.Error); ok && e.Code() == "ResourceInUseException" {
+		err = nil // already exists
+	}
+	if err != nil {
+		return err
+	}
+	return db.waitTable(context.TODO(), tbl)
+}
+
+const timeFormat = time.RFC3339Nano
+
+func str(s string) *dynamodb.AttributeValue {
+	return &dynamodb.AttributeValue{S: aws.String(s)}
+}
+
+func int64Attr(v int64) *dynamodb.AttributeValue {
+	return &dynamodb.AttributeValue{N: aws.String(strconv.FormatInt(int64(v), 10))}
+}
+
+const (
+	fldType = "_type"
+	fldVal  = "_val"
+
+	typeTime = "time"
+)
+
+func toAwsValue(v nosql.Value) *dynamodb.AttributeValue {
+	switch v := v.(type) {
+	case nil:
+		return &dynamodb.AttributeValue{NULL: aws.Bool(true)}
+	case nosql.Document:
+		_, ok1 := v[fldType]
+		_, ok2 := v[fldVal]
+		if ok1 || ok2 {
+			panic(fmt.Errorf("document collides with internal types: %v", v))
+		}
+		return &dynamodb.AttributeValue{M: toAwsDoc(v)}
+	case nosql.Array:
+		arr := make([]*dynamodb.AttributeValue, 0, len(v))
+		for _, s := range v {
+			arr = append(arr, toAwsValue(s))
+		}
+		return &dynamodb.AttributeValue{L: arr}
+	case nosql.String:
+		return str(string(v))
+	case nosql.Int:
+		return int64Attr(int64(v))
+	case nosql.Float:
+		// save float value in exp notation so they never be mistaken with ints
+		return &dynamodb.AttributeValue{N: aws.String(strconv.FormatFloat(float64(v), 'e', -1, 64))}
+	case nosql.Bool:
+		return &dynamodb.AttributeValue{BOOL: aws.Bool(bool(v))}
+	case nosql.Time:
+		return &dynamodb.AttributeValue{M: map[string]*dynamodb.AttributeValue{
+			fldType: str(typeTime),
+			fldVal:  str(time.Time(v).Format(timeFormat)),
+		}}
+	case nosql.Bytes:
+		return &dynamodb.AttributeValue{B: []byte(v)}
+	default:
+		panic(fmt.Errorf("unsupported type: %T", v))
+	}
+}
+func fromAwsValue(v *dynamodb.AttributeValue) nosql.Value {
+	if v == nil {
+		return nil
+	}
+	switch {
+	case v.NULL != nil && *v.NULL:
+		return nil
+	case v.M != nil:
+		if typ := v.M[fldType]; typ != nil && typ.S != nil {
+			val := v.M[fldVal]
+			var v string
+			if val != nil && val.S != nil {
+				v = *val.S
+			}
+			switch *typ.S {
+			case typeTime:
+				t, _ := time.Parse(timeFormat, v)
+				return nosql.Time(t)
+			default:
+				panic(fmt.Errorf("unsupported data type: %q", *typ.S))
+			}
+		}
+		return fromAwsDoc(v.M)
+	case v.L != nil:
+		arr := make(nosql.Array, 0, len(v.L))
+		for _, s := range v.L {
+			arr = append(arr, fromAwsValue(s))
+		}
+		return arr
+	case v.SS != nil:
+		arr := make(nosql.Array, 0, len(v.SS))
+		for _, s := range v.SS {
+			arr = append(arr, nosql.String(*s))
+		}
+		return arr
+	case v.S != nil:
+		return nosql.String(*v.S)
+	case v.N != nil:
+		if iv, err := strconv.ParseInt(*v.N, 10, 64); err == nil {
+			return nosql.Int(iv)
+		}
+		fv, _ := strconv.ParseFloat(*v.N, 64)
+		return nosql.Float(fv)
+	case v.BOOL != nil:
+		return nosql.Bool(*v.BOOL)
+	case v.B != nil:
+		return nosql.Bytes(v.B)
+	default:
+		panic(fmt.Errorf("unsupported type: %+v", v))
+	}
+}
+func toAwsDoc(d nosql.Document) map[string]*dynamodb.AttributeValue {
+	if d == nil {
+		return nil
+	}
+	m := make(map[string]*dynamodb.AttributeValue, len(d))
+	for k, v := range d {
+		m[k] = toAwsValue(v)
+	}
+	return m
+}
+func fromAwsDoc(d map[string]*dynamodb.AttributeValue) nosql.Document {
+	if d == nil {
+		return nil
+	}
+	m := make(nosql.Document, len(d))
+	for k, v := range d {
+		m[k] = fromAwsValue(v)
+	}
+	return m
+}
+
+func genID() string {
+	return uuid.NewUUID().String()
+}
+
+func (db *DB) Insert(col string, id string, d nosql.Document) (string, error) {
+	if id == "" {
+		id = genID()
+	}
+	item := toAwsDoc(d)
+	item[nosql.IDField] = str(id)
+	_, err := db.db.PutItem(&dynamodb.PutItemInput{
+		TableName:           db.col(col),
+		ConditionExpression: aws.String("attribute_not_exists(#id)"),
+		ExpressionAttributeNames: map[string]*string{
+			"#id": aws.String(nosql.IDField),
+		},
+		Item: item,
+	})
+	if err != nil {
+		return "", err
+	}
+	return id, nil
+}
+func (db *DB) FindByID(col string, id string) (nosql.Document, error) {
+	resp, err := db.db.GetItem(&dynamodb.GetItemInput{
+		TableName: db.col(col),
+		Key: map[string]*dynamodb.AttributeValue{
+			nosql.IDField: str(id),
+		},
+	})
+	if err != nil {
+		return nil, convError(err)
+	} else if len(resp.Item) == 0 {
+		return nil, nosql.ErrNotFound
+	}
+	return fromAwsDoc(resp.Item), nil
+}
+func (db *DB) Query(col string) nosql.Query {
+	return &Query{db: db.db, col: db.col(col), f: newFilter()}
+}
+func (db *DB) Update(col string, id string) nosql.Update {
+	return &Update{
+		db: db.db, col: db.col(col), id: id,
+		names: make(map[string]*string),
+		vals:  make(map[string]*dynamodb.AttributeValue),
+	}
+}
+func (db *DB) Delete(col string) nosql.Delete {
+	return &Delete{db: db.db, col: db.col(col), f: newFilter()}
+}
+
+func newFilter() Filter {
+	return Filter{
+		names: make(map[string]*string),
+		vals:  make(map[string]*dynamodb.AttributeValue),
+	}
+}
+
+type Filter struct {
+	cond  []string
+	names map[string]*string
+	vals  map[string]*dynamodb.AttributeValue
+	last  int
+}
+
+func (fl *Filter) nextName() string {
+	fl.last++
+	n := fl.last
+	return fmt.Sprintf("p%d", n)
+}
+func (fl *Filter) Expr() *string {
+	if len(fl.cond) == 0 {
+		return nil
+	}
+	return aws.String(strings.Join(fl.cond, " AND "))
+}
+func (fl *Filter) Names() map[string]*string {
+	if len(fl.names) == 0 {
+		return nil
+	}
+	return fl.names
+}
+func (fl *Filter) Values() map[string]*dynamodb.AttributeValue {
+	if len(fl.vals) == 0 {
+		return nil
+	}
+	return fl.vals
+}
+
+func cloneStrings(arr []string) []string {
+	out := make([]string, len(arr))
+	copy(out, arr)
+	return out
+}
+
+func (fl *Filter) Append(filters []nosql.FieldFilter) {
+	for _, f := range filters {
+		if t, ok := f.Value.(nosql.Time); ok {
+			// time is different - we need to check the type and change field name
+			fl.Append([]nosql.FieldFilter{
+				{
+					Path:   append(cloneStrings(f.Path), fldType),
+					Filter: nosql.Equal,
+					Value:  nosql.String(typeTime),
+				},
+				{
+					Path:   append(cloneStrings(f.Path), fldVal),
+					Filter: f.Filter,
+					Value:  nosql.String(time.Time(t).Format(timeFormat)),
+				},
+			})
+			continue
+		}
+		var (
+			op string
+		)
+		switch f.Filter {
+		case nosql.Equal:
+			op = "="
+		case nosql.NotEqual:
+			op = "<>"
+		case nosql.GT:
+			op = ">"
+		case nosql.GTE:
+			op = ">="
+		case nosql.LT:
+			op = "<"
+		case nosql.LTE:
+			op = "<="
+		default:
+			panic(fmt.Errorf("unsupported filter: %v", f.Filter))
+		}
+		// escape field names to avoid reserved words
+		names := make([]string, 0, len(f.Path))
+		for _, name := range f.Path {
+			pname := fl.nextName()
+			fl.names["#"+pname] = aws.String(name)
+			names = append(names, "#"+pname)
+		}
+		fname := strings.Join(names, ".")
+
+		// add a placeholder for value
+		vname := fl.nextName()
+		val := toAwsValue(f.Value)
+		fl.vals[":"+vname] = val
+
+		// and finally add filter
+		cond := strings.Join([]string{"(", fname, op, ":" + vname, ")"}, " ")
+		fl.cond = append(fl.cond, cond)
+	}
+}
+
+type Query struct {
+	db    *dynamodb.DynamoDB
+	col   *string
+	limit int
+
+	f Filter
+}
+
+func (q *Query) WithFields(filters ...nosql.FieldFilter) nosql.Query {
+	q.f.Append(filters)
+	return q
+}
+func (q *Query) Limit(n int) nosql.Query {
+	q.limit = n
+	return q
+}
+func (q *Query) build() *dynamodb.ScanInput {
+	// TODO: split id into hash and range keys and run Query instead of Scan
+	qu := &dynamodb.ScanInput{
+		TableName:                 q.col,
+		FilterExpression:          q.f.Expr(),
+		ExpressionAttributeNames:  q.f.Names(),
+		ExpressionAttributeValues: q.f.Values(),
+	}
+	if q.limit > 0 {
+		qu.Limit = aws.Int64(int64(q.limit))
+	}
+	return qu
+}
+func (q *Query) Count(ctx context.Context) (int64, error) {
+	qu := q.build()
+	qu.Select = aws.String(dynamodb.SelectCount)
+	resp, err := q.db.Scan(qu)
+	if err != nil {
+		return 0, err
+	}
+	return *resp.Count, nil
+}
+func (q *Query) One(ctx context.Context) (nosql.Document, error) {
+	qu := q.build()
+	qu.Limit = aws.Int64(1)
+	resp, err := q.db.Scan(qu)
+	if err != nil {
+		return nil, err
+	} else if len(resp.Items) == 0 {
+		return nil, nosql.ErrNotFound
+	}
+	return fromAwsDoc(resp.Items[0]), nil
+}
+func (q *Query) Iterate() nosql.DocIterator {
+	qu := q.build()
+	return &Iterator{db: q.db, q: qu}
+}
+
+type Iterator struct {
+	db *dynamodb.DynamoDB
+	q  *dynamodb.ScanInput
+
+	buf []map[string]*dynamodb.AttributeValue
+	i   int
+	err error
+}
+
+func (it *Iterator) Next(ctx context.Context) bool {
+	if it.i+1 < len(it.buf) {
+		it.i++
+		return true
+	} else if it.q == nil {
+		return false
+	}
+	for {
+		resp, err := it.db.ScanWithContext(ctx, it.q)
+		if err != nil {
+			it.err = err
+			return false
+		}
+		it.i = 0
+		it.buf = resp.Items
+		if resp.LastEvaluatedKey == nil {
+			it.q = nil
+		} else {
+			it.q.ExclusiveStartKey = resp.LastEvaluatedKey
+		}
+		if len(it.buf) > 0 {
+			return true
+		} else if it.q == nil {
+			return false
+		}
+	}
+}
+func (it *Iterator) Err() error {
+	return it.err
+}
+func (it *Iterator) Close() error {
+	it.buf = nil
+	return nil
+}
+func (it *Iterator) item() map[string]*dynamodb.AttributeValue {
+	if it.i < len(it.buf) {
+		return it.buf[it.i]
+	}
+	return nil
+}
+func (it *Iterator) ID() string {
+	f := it.item()[nosql.IDField]
+	if f != nil && f.S != nil {
+		return string(*f.S)
+	}
+	return ""
+}
+func (it *Iterator) Doc() nosql.Document {
+	return fromAwsDoc(it.item())
+}
+
+type Delete struct {
+	db  *dynamodb.DynamoDB
+	col *string
+	ids []string
+	f   Filter
+}
+
+func (d *Delete) WithFields(filters ...nosql.FieldFilter) nosql.Delete {
+	d.f.Append(filters)
+	return d
+}
+func (d *Delete) IDs(ids ...string) nosql.Delete {
+	d.ids = append(d.ids, ids...)
+	return d
+}
+func (d *Delete) Do(ctx context.Context) error {
+	if len(d.ids) == 0 {
+		return fmt.Errorf("expected one or more object ids")
+	}
+	req := dynamodb.DeleteItemInput{
+		TableName:                 d.col,
+		ConditionExpression:       d.f.Expr(),
+		ExpressionAttributeNames:  d.f.Names(),
+		ExpressionAttributeValues: d.f.Values(),
+	}
+	for _, id := range d.ids {
+		r := req
+		r.Key = map[string]*dynamodb.AttributeValue{
+			nosql.IDField: str(id),
+		}
+		_, err := d.db.DeleteItem(&r)
+		if e, ok := err.(awserr.Error); ok {
+			switch e.Code() {
+			case "ConditionalCheckFailedException":
+				err = nil
+			}
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type Update struct {
+	db  *dynamodb.DynamoDB
+	col *string
+	id  string
+
+	add    []string
+	set    []string
+	names  map[string]*string
+	vals   map[string]*dynamodb.AttributeValue
+	upsert bool
+}
+
+func (u *Update) Inc(field string, dn int) nosql.Update {
+	fl := strings.ToLower(field)
+	u.names["#"+fl] = aws.String(field)
+	u.vals[":"+fl] = int64Attr(int64(dn))
+	u.add = append(u.add, "#"+fl+" :"+fl)
+	return u
+}
+func (u *Update) Push(field string, v nosql.Value) nosql.Update {
+	fl := strings.ToLower(field)
+	u.names["#"+fl] = aws.String(field)
+	var av *dynamodb.AttributeValue
+	switch v := v.(type) {
+	case nosql.Int:
+		av = &dynamodb.AttributeValue{NS: []*string{int64Attr(int64(v)).N}}
+	case nosql.String:
+		av = &dynamodb.AttributeValue{SS: []*string{aws.String(string(v))}}
+	default:
+		// TODO: this most probably will lead to error, but we don't use this code path
+		av = &dynamodb.AttributeValue{L: []*dynamodb.AttributeValue{
+			toAwsValue(v),
+		}}
+	}
+	u.vals[":"+fl] = av
+	u.add = append(u.add, "#"+fl+" :"+fl)
+	return u
+}
+func (u *Update) Upsert(d nosql.Document) nosql.Update {
+	u.upsert = true
+	upsert := toAwsDoc(d)
+	delete(upsert, nosql.IDField)
+	for k, v := range upsert {
+		kl := strings.ToLower(k)
+		if _, ok := u.names["#"+kl]; !ok {
+			u.names["#"+kl] = aws.String(k)
+			u.vals[":"+kl] = v
+			u.set = append(u.set, "#"+kl+" = :"+kl)
+		}
+	}
+	return u
+}
+func (u *Update) Do(ctx context.Context) error {
+	req := &dynamodb.UpdateItemInput{
+		TableName: u.col,
+		Key: map[string]*dynamodb.AttributeValue{
+			nosql.IDField: str(u.id),
+		},
+	}
+	if len(u.names) != 0 {
+		req.ExpressionAttributeNames = u.names
+		req.ExpressionAttributeValues = u.vals
+	}
+	if !u.upsert {
+		req.ConditionExpression = aws.String("attribute_not_exists(" + nosql.IDField + ")")
+	}
+	upd := ""
+	if len(u.add) != 0 {
+		upd += "ADD " + strings.Join(u.add, ", ") + " "
+	}
+	if len(u.set) != 0 {
+		upd += "SET " + strings.Join(u.set, ", ") + " "
+	}
+	req.UpdateExpression = aws.String(upd)
+	_, err := u.db.UpdateItem(req)
+	return err
+}

--- a/graph/nosql/dynamo/dynamo_test.go
+++ b/graph/nosql/dynamo/dynamo_test.go
@@ -1,0 +1,76 @@
+package dynamo
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+
+	"github.com/cayleygraph/cayley/graph"
+	"github.com/cayleygraph/cayley/graph/nosql"
+	"github.com/cayleygraph/cayley/graph/nosql/nosqltest"
+)
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
+
+var (
+	awsAccessKey = os.Getenv("AWS_ACCESS_KEY")
+	awsSecretKey = os.Getenv("AWS_SECRET_KEY")
+	awsRegion    = os.Getenv("AWS_REGION")
+)
+
+func makeDynamo(t testing.TB) (nosql.Database, graph.Options, func()) {
+	if awsAccessKey == "" || awsSecretKey == "" || awsRegion == "" {
+		t.SkipNow()
+	}
+	opt := graph.Options{
+		"accessKey": awsAccessKey,
+		"secretKey": awsSecretKey,
+		"region":    awsRegion,
+	}
+	pref := fmt.Sprintf("cayley_test_%x", rand.Int())
+
+	db, err := newDB(pref, opt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("dynamodb table prefix: %q", pref)
+	return db, nil, func() {
+		req := &dynamodb.ListTablesInput{ExclusiveStartTableName: aws.String(pref)}
+		for {
+			resp, err := db.db.ListTables(req)
+			if err != nil {
+				t.Logf("cannot list tables: %v", err)
+				return
+			} else if len(resp.TableNames) == 0 {
+				return
+			}
+			req.ExclusiveStartTableName = resp.LastEvaluatedTableName
+			for _, name := range resp.TableNames {
+				if name == nil || !strings.HasPrefix(*name, pref) {
+					continue
+				}
+				_, err = db.db.DeleteTable(&dynamodb.DeleteTableInput{
+					TableName: name,
+				})
+				if err != nil {
+					t.Logf("cannot remove table %q: %v", *name, err)
+				}
+			}
+			if resp.LastEvaluatedTableName == nil {
+				return
+			}
+		}
+	}
+}
+
+func TestDynamo(t *testing.T) {
+	nosqltest.TestAll(t, makeDynamo, nil)
+}

--- a/graph/nosql/indexed_linksto.go
+++ b/graph/nosql/indexed_linksto.go
@@ -1,0 +1,263 @@
+// Copyright 2014 The Cayley Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nosql
+
+/*
+import (
+	"gopkg.in/mgo.v2/bson"
+
+	"github.com/cayleygraph/cayley/graph"
+	"github.com/cayleygraph/cayley/graph/iterator"
+	"github.com/cayleygraph/cayley/quad"
+)
+
+var _ graph.Iterator = &LinksTo{}
+
+// LinksTo is a MongoDB-dependent version of a LinksTo iterator. Like the normal
+// LinksTo, it represents a set of links to a set of nodes, represented by its
+// subiterator. However, this iterator may often be faster than the generic
+// LinksTo, as it can use the secondary indices in Mongo as features within the
+// Mongo query, reducing the size of the result set and speeding up iteration.
+type LinksTo struct {
+	uid        uint64
+	collection string
+	tags       graph.Tagger
+	qs         *QuadStore
+	primaryIt  graph.Iterator
+	dir        quad.Direction
+	nextIt     DocIterator
+	result     graph.Value
+	runstats   graph.IteratorStats
+	lset       []graph.Linkage
+	err        error
+}
+
+// NewLinksTo constructs a new indexed LinksTo iterator for Mongo around a direction
+// and a subiterator of nodes.
+func NewLinksTo(qs *QuadStore, it graph.Iterator, collection string, d quad.Direction, lset []graph.Linkage) *LinksTo {
+	return &LinksTo{
+		uid:        iterator.NextUID(),
+		qs:         qs,
+		primaryIt:  it,
+		dir:        d,
+		nextIt:     nil,
+		lset:       lset,
+		collection: collection,
+	}
+}
+
+func (it *LinksTo) buildConstraint() []FieldFilter {
+	filters := make([]FieldFilter, 0, len(it.lset)+1)
+	// TODO(barakmich): Currently this only works for an individual linkage in any direction.
+	for _, link := range it.lset {
+		filters = append(filters, FieldFilter{
+			Field:  link.Dir.String(),
+			Filter: Equal,
+			Value:  String(link.Value.(NodeHash)),
+		})
+	}
+	return filters
+}
+
+func (it *LinksTo) buildIteratorFor(d quad.Direction, val graph.Value) DocIterator {
+	filters := it.buildConstraint()
+	filters = append(filters, FieldFilter{
+		Field:  d.String(),
+		Filter: Equal,
+		Value:  String(val.(NodeHash)),
+	})
+	return it.qs.db.Query(it.collection).WithFields(filters...).Iterate()
+}
+
+func (it *LinksTo) UID() uint64 {
+	return it.uid
+}
+
+func (it *LinksTo) Tagger() *graph.Tagger {
+	return &it.tags
+}
+
+// Return the direction under consideration.
+func (it *LinksTo) Direction() quad.Direction { return it.dir }
+
+// Tag these results, and our subiterator's results.
+func (it *LinksTo) TagResults(dst map[string]graph.Value) {
+	it.tags.TagResult(dst, it.Result())
+
+	it.primaryIt.TagResults(dst)
+}
+
+// Optimize the LinksTo, by replacing it if it can be.
+func (it *LinksTo) Optimize() (graph.Iterator, bool) {
+	return it, false
+}
+
+func (it *LinksTo) Next() bool {
+	var result struct {
+		ID      string     `bson:"_id"`
+		Added   []bson.Raw `bson:"Added"`
+		Deleted []bson.Raw `bson:"Deleted"`
+	}
+	graph.NextLogIn(it)
+next:
+	for {
+		it.runstats.Next += 1
+		if it.nextIt != nil && it.nextIt.Next(&result) {
+			it.runstats.ContainsNext += 1
+			if it.collection == "quads" && len(result.Added) <= len(result.Deleted) {
+				continue next
+			}
+			it.result = QuadHash(result.ID)
+			return graph.NextLogOut(it, true)
+		}
+
+		if it.nextIt != nil {
+			// If there's an error in the 'next' iterator, we save it and we're done.
+			it.err = it.nextIt.Err()
+			if it.err != nil {
+				return false
+			}
+
+		}
+		// Subiterator is empty, get another one
+		if !it.primaryIt.Next() {
+			// Possibly save error
+			it.err = it.primaryIt.Err()
+
+			// We're out of nodes in our subiterator, so we're done as well.
+			return graph.NextLogOut(it, false)
+		}
+		if it.nextIt != nil {
+			it.nextIt.Close()
+		}
+		it.nextIt = it.buildIteratorFor(it.dir, it.primaryIt.Result())
+
+		// Recurse -- return the first in the next set.
+	}
+}
+
+func (it *LinksTo) Err() error {
+	return it.err
+}
+
+func (it *LinksTo) Result() graph.Value {
+	return it.result
+}
+
+func (it *LinksTo) Close() error {
+	var err error
+	if it.nextIt != nil {
+		err = it.nextIt.Close()
+	}
+
+	_err := it.primaryIt.Close()
+	if _err != nil && err == nil {
+		err = _err
+	}
+
+	return err
+}
+
+func (it *LinksTo) NextPath() bool {
+	ok := it.primaryIt.NextPath()
+	if !ok {
+		it.err = it.primaryIt.Err()
+	}
+	return ok
+}
+
+func (it *LinksTo) Type() graph.Type {
+	return "mongo-linksto"
+}
+
+func (it *LinksTo) Clone() graph.Iterator {
+	m := NewLinksTo(it.qs, it.primaryIt.Clone(), it.collection, it.dir, it.lset)
+	m.tags.CopyFrom(it)
+	return m
+}
+
+func (it *LinksTo) Contains(val graph.Value) bool {
+	graph.ContainsLogIn(it, val)
+	it.runstats.Contains += 1
+
+	for _, link := range it.lset {
+		dval := it.qs.QuadDirection(val, link.Dir)
+		if dval != link.Value {
+			return graph.ContainsLogOut(it, val, false)
+		}
+	}
+
+	node := it.qs.QuadDirection(val, it.dir)
+	if it.primaryIt.Contains(node) {
+		it.result = val
+		return graph.ContainsLogOut(it, val, true)
+	}
+	it.err = it.primaryIt.Err()
+	return graph.ContainsLogOut(it, val, false)
+}
+
+func (it *LinksTo) Describe() graph.Description {
+	primary := it.primaryIt.Describe()
+	return graph.Description{
+		UID:       it.UID(),
+		Type:      it.Type(),
+		Direction: it.dir,
+		Iterator:  &primary,
+	}
+}
+
+func (it *LinksTo) Reset() {
+	it.primaryIt.Reset()
+	if it.nextIt != nil {
+		it.nextIt.Close()
+	}
+	it.nextIt = nil
+}
+
+// Return a guess as to how big or costly it is to next the iterator.
+func (it *LinksTo) Stats() graph.IteratorStats {
+	subitStats := it.primaryIt.Stats()
+	// TODO(barakmich): These should really come from the quadstore itself
+	fanoutFactor := int64(20)
+	checkConstant := int64(1)
+	nextConstant := int64(2)
+
+	size := fanoutFactor * subitStats.Size
+	csize, _ := it.qs.getSize(it.collection, it.buildConstraint())
+	if size > csize {
+		size = csize
+	}
+
+	return graph.IteratorStats{
+		NextCost:     nextConstant + subitStats.NextCost,
+		ContainsCost: checkConstant + subitStats.ContainsCost,
+		Size:         size,
+		ExactSize:    false,
+		Next:         it.runstats.Next,
+		Contains:     it.runstats.Contains,
+		ContainsNext: it.runstats.ContainsNext,
+	}
+}
+
+func (it *LinksTo) Size() (int64, bool) {
+	st := it.Stats()
+	return st.Size, st.ExactSize
+}
+
+// Return a list containing only our subiterator.
+func (it *LinksTo) SubIterators() []graph.Iterator {
+	return []graph.Iterator{it.primaryIt}
+}
+*/

--- a/graph/nosql/iterator.go
+++ b/graph/nosql/iterator.go
@@ -1,0 +1,232 @@
+// Copyright 2014 The Cayley Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nosql
+
+import (
+	"context"
+
+	"github.com/cayleygraph/cayley/clog"
+	"github.com/cayleygraph/cayley/graph"
+	"github.com/cayleygraph/cayley/graph/iterator"
+	"github.com/cayleygraph/cayley/quad"
+)
+
+type Iterator struct {
+	uid        uint64
+	tags       graph.Tagger
+	qs         *QuadStore
+	dir        quad.Direction
+	iter       DocIterator
+	hash       NodeHash
+	size       int64
+	isAll      bool
+	constraint []FieldFilter
+	collection string
+	result     graph.Value
+	err        error
+}
+
+func NewIterator(qs *QuadStore, collection string, d quad.Direction, val graph.Value) *Iterator {
+	h := val.(NodeHash)
+
+	constraints := []FieldFilter{{
+		Path:   []string{d.String()},
+		Filter: Equal,
+		Value:  String(h),
+	}}
+
+	return &Iterator{
+		uid:        iterator.NextUID(),
+		constraint: constraints,
+		collection: collection,
+		qs:         qs,
+		dir:        d,
+		iter:       nil,
+		size:       -1,
+		hash:       h,
+		isAll:      false,
+	}
+}
+
+func (it *Iterator) makeIterator() DocIterator {
+	q := it.qs.db.Query(it.collection)
+	if !it.isAll {
+		q = q.WithFields(it.constraint...)
+	}
+	return q.Iterate()
+}
+
+func NewAllIterator(qs *QuadStore, collection string) *Iterator {
+	return &Iterator{
+		uid:        iterator.NextUID(),
+		qs:         qs,
+		dir:        quad.Any,
+		constraint: nil,
+		collection: collection,
+		iter:       nil,
+		size:       -1,
+		hash:       "",
+		isAll:      true,
+	}
+}
+
+func NewIteratorWithConstraints(qs *QuadStore, collection string, constraints []FieldFilter) *Iterator {
+	return &Iterator{
+		uid:        iterator.NextUID(),
+		qs:         qs,
+		dir:        quad.Any,
+		constraint: constraints,
+		collection: collection,
+		iter:       nil,
+		size:       -1,
+		hash:       "",
+		isAll:      false,
+	}
+}
+
+func (it *Iterator) UID() uint64 {
+	return it.uid
+}
+
+func (it *Iterator) Reset() {
+	it.Close()
+	it.iter = it.makeIterator()
+
+}
+
+func (it *Iterator) Close() error {
+	if it.iter != nil {
+		return it.iter.Close()
+	}
+	return nil
+}
+
+func (it *Iterator) Tagger() *graph.Tagger {
+	return &it.tags
+}
+
+func (it *Iterator) TagResults(dst map[string]graph.Value) {
+	it.tags.TagResult(dst, it.Result())
+}
+
+func (it *Iterator) Clone() graph.Iterator {
+	var m *Iterator
+	if it.isAll {
+		m = NewAllIterator(it.qs, it.collection)
+	} else {
+		m = NewIterator(it.qs, it.collection, it.dir, NodeHash(it.hash))
+	}
+	m.tags.CopyFrom(it)
+	return m
+}
+
+func (it *Iterator) Next() bool {
+	if it.iter == nil {
+		it.iter = it.makeIterator()
+	}
+	if !it.iter.Next(context.TODO()) {
+		err := it.iter.Err()
+		if err != nil {
+			it.err = err
+			clog.Errorf("Error Nexting Iterator: %v", err)
+		}
+		return false
+	}
+	doc := it.iter.Doc()
+	if it.collection == colQuads && !checkQuadValid(doc) {
+		return it.Next()
+	}
+	id, _ := doc[IDField].(String)
+	if it.collection == colQuads {
+		it.result = QuadHash(id)
+	} else {
+		it.result = NodeHash(id)
+	}
+	return true
+}
+
+func (it *Iterator) Err() error {
+	return it.err
+}
+
+func (it *Iterator) Result() graph.Value {
+	return it.result
+}
+
+func (it *Iterator) NextPath() bool {
+	return false
+}
+
+// SubIterators returns no subiterators for a Mongo iterator.
+func (it *Iterator) SubIterators() []graph.Iterator {
+	return nil
+}
+
+func (it *Iterator) Contains(v graph.Value) bool {
+	graph.ContainsLogIn(it, v)
+	if it.isAll {
+		it.result = v
+		return graph.ContainsLogOut(it, v, true)
+	}
+	val := NodeHash(v.(QuadHash).Get(it.dir))
+	if val == it.hash {
+		it.result = v
+		return graph.ContainsLogOut(it, v, true)
+	}
+	return graph.ContainsLogOut(it, v, false)
+}
+
+func (it *Iterator) Size() (int64, bool) {
+	if it.size == -1 {
+		var err error
+		it.size, err = it.qs.getSize(it.collection, it.constraint)
+		if err != nil {
+			it.err = err
+		}
+	}
+	return it.size, true
+}
+
+func (it *Iterator) Type() graph.Type {
+	if it.isAll {
+		return graph.All
+	}
+	return "nosql"
+}
+
+func (it *Iterator) Sorted() bool                     { return true }
+func (it *Iterator) Optimize() (graph.Iterator, bool) { return it, false }
+
+func (it *Iterator) Describe() graph.Description {
+	size, _ := it.Size()
+	return graph.Description{
+		UID:  it.UID(),
+		Name: string(it.hash),
+		Type: it.Type(),
+		Size: size,
+	}
+}
+
+func (it *Iterator) Stats() graph.IteratorStats {
+	size, exact := it.Size()
+	return graph.IteratorStats{
+		ContainsCost: 1,
+		NextCost:     5,
+		Size:         size,
+		ExactSize:    exact,
+	}
+}
+
+var _ graph.Iterator = &Iterator{}

--- a/graph/nosql/iterator.go
+++ b/graph/nosql/iterator.go
@@ -148,10 +148,16 @@ func (it *Iterator) Next() bool {
 	if it.collection == colQuads && !checkQuadValid(doc) {
 		return it.Next()
 	}
-	id, _ := doc[IDField].(String)
 	if it.collection == colQuads {
-		it.result = QuadHash(id)
+		sh, _ := doc[fldSubject].(String)
+		ph, _ := doc[fldPredicate].(String)
+		oh, _ := doc[fldObject].(String)
+		lh, _ := doc[fldLabel].(String)
+		it.result = QuadHash{
+			string(sh), string(ph), string(oh), string(lh),
+		}
 	} else {
+		id, _ := doc[fldID].(String)
 		it.result = NodeHash(id)
 	}
 	return true

--- a/graph/nosql/mongo/mongo.go
+++ b/graph/nosql/mongo/mongo.go
@@ -1,0 +1,426 @@
+package mongo
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"time"
+
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+
+	"github.com/cayleygraph/cayley/graph"
+	"github.com/cayleygraph/cayley/graph/nosql"
+)
+
+const Type = "mongo"
+
+func init() {
+	nosql.Register(Type, nosql.Registration{
+		NewFunc:      Open,
+		InitFunc:     Create,
+		IsPersistent: true,
+	})
+}
+
+func dialMongo(addr string, options graph.Options) (*mgo.Session, error) {
+	if connVal, ok := options["session"]; ok {
+		if conn, ok := connVal.(*mgo.Session); ok {
+			return conn, nil
+		}
+	}
+	if strings.HasPrefix(addr, "mongodb://") || strings.ContainsAny(addr, `@/\`) {
+		// full mongodb url
+		return mgo.Dial(addr)
+	}
+	var dialInfo mgo.DialInfo
+	dialInfo.Addrs = strings.Split(addr, ",")
+	user, ok, err := options.StringKey("username")
+	if err != nil {
+		return nil, err
+	}
+	if ok {
+		dialInfo.Username = user
+		password, ok, err := options.StringKey("password")
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			dialInfo.Password = password
+		}
+	}
+	dbName := nosql.DefaultDBName
+	val, ok, err := options.StringKey("database_name")
+	if err != nil {
+		return nil, err
+	}
+	if ok {
+		dbName = val
+	}
+	dialInfo.Database = dbName
+	return mgo.DialWithInfo(&dialInfo)
+}
+
+func dialDB(addr string, opt graph.Options) (*DB, error) {
+	sess, err := dialMongo(addr, opt)
+	if err != nil {
+		return nil, err
+	}
+	return &DB{sess: sess, db: sess.DB("")}, nil
+}
+
+func Create(addr string, opt graph.Options) (nosql.Database, error) {
+	return dialDB(addr, opt)
+}
+
+func Open(addr string, opt graph.Options) (nosql.Database, error) {
+	return dialDB(addr, opt)
+}
+
+type DB struct {
+	sess *mgo.Session
+	db   *mgo.Database
+}
+
+func (db *DB) Close() error {
+	db.sess.Close()
+	return nil
+}
+func (db *DB) EnsureIndex(col string, indexes ...nosql.Index) error {
+	c := db.db.C(col)
+	for _, ind := range indexes {
+		err := c.EnsureIndex(mgo.Index{
+			Key:        []string{ind.Field},
+			Unique:     false,
+			DropDups:   false,
+			Background: true,
+			Sparse:     true,
+		})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+func toBsonValue(v nosql.Value) interface{} {
+	switch v := v.(type) {
+	case nil:
+		return nil
+	case nosql.Document:
+		return toBsonDoc(v)
+	case nosql.Array:
+		arr := make([]interface{}, 0, len(v))
+		for _, s := range v {
+			arr = append(arr, toBsonValue(s))
+		}
+		return arr
+	case nosql.String:
+		return string(v)
+	case nosql.Int:
+		return int64(v)
+	case nosql.Float:
+		return float64(v)
+	case nosql.Bool:
+		return bool(v)
+	case nosql.Time:
+		return time.Time(v)
+	case nosql.Bytes:
+		return []byte(v)
+	default:
+		panic(fmt.Errorf("unsupported type: %T", v))
+	}
+}
+func fromBsonValue(v interface{}) nosql.Value {
+	switch v := v.(type) {
+	case nil:
+		return nil
+	case bson.M:
+		return fromBsonDoc(v)
+	case []interface{}:
+		arr := make(nosql.Array, 0, len(v))
+		for _, s := range v {
+			arr = append(arr, fromBsonValue(s))
+		}
+		return arr
+	case bson.ObjectId:
+		return nosql.String(objidString(v))
+	case string:
+		return nosql.String(v)
+	case int:
+		return nosql.Int(v)
+	case int64:
+		return nosql.Int(v)
+	case float64:
+		return nosql.Float(v)
+	case bool:
+		return nosql.Bool(v)
+	case time.Time:
+		return nosql.Time(v)
+	case []byte:
+		return nosql.Bytes(v)
+	default:
+		panic(fmt.Errorf("unsupported type: %T", v))
+	}
+}
+func toBsonDoc(d nosql.Document) bson.M {
+	if d == nil {
+		return nil
+	}
+	m := make(bson.M, len(d))
+	for k, v := range d {
+		m[k] = toBsonValue(v)
+	}
+	return m
+}
+func fromBsonDoc(d bson.M) nosql.Document {
+	if d == nil {
+		return nil
+	}
+	m := make(nosql.Document, len(d))
+	for k, v := range d {
+		m[k] = fromBsonValue(v)
+	}
+	return m
+}
+
+const idField = "_id"
+
+func convRootDoc(m bson.M) nosql.Document {
+	d := fromBsonDoc(m)
+	if id, ok := d[idField]; ok {
+		delete(d, idField)
+		d[nosql.IDField] = id
+	}
+	return d
+}
+
+func objidString(id bson.ObjectId) string {
+	return hex.EncodeToString([]byte(id))
+}
+
+func (db *DB) Insert(col string, id string, d nosql.Document) (string, error) {
+	m := toBsonDoc(d)
+	var mid interface{}
+	if id == "" {
+		oid := bson.NewObjectId()
+		mid = oid
+		id = objidString(oid)
+	} else {
+		mid = id
+	}
+	m[idField] = mid
+	delete(m, nosql.IDField)
+	if err := db.db.C(col).Insert(m); err != nil {
+		return "", err
+	}
+	return id, nil
+}
+func (db *DB) FindByID(col string, id string) (nosql.Document, error) {
+	var m bson.M
+	err := db.db.C(col).FindId(id).One(&m)
+	if err == mgo.ErrNotFound {
+		return nil, nosql.ErrNotFound
+	} else if err != nil {
+		return nil, err
+	}
+	return fromBsonDoc(m), nil
+}
+func (db *DB) Query(col string) nosql.Query {
+	return &Query{col: db.db.C(col)}
+}
+func (db *DB) Update(col string, id string) nosql.Update {
+	return &Update{col: db.db.C(col), id: id, update: make(bson.M)}
+}
+func (db *DB) Delete(col string) nosql.Delete {
+	return &Delete{col: db.db.C(col)}
+}
+
+func buildFilters(filters []nosql.FieldFilter) bson.M {
+	m := make(bson.M, len(filters))
+	for _, f := range filters {
+		v := toBsonValue(f.Value)
+		var mf interface{}
+		switch f.Filter {
+		case nosql.Equal:
+			mf = v
+		case nosql.NotEqual:
+			mf = bson.M{"$ne": v}
+		case nosql.GT:
+			mf = bson.M{"$gt": v}
+		case nosql.GTE:
+			mf = bson.M{"$gte": v}
+		case nosql.LT:
+			mf = bson.M{"$lt": v}
+		case nosql.LTE:
+			mf = bson.M{"$lte": v}
+		default:
+			panic(fmt.Errorf("unsupported filter: %v", f.Filter))
+		}
+		m[strings.Join(f.Path, ".")] = mf
+	}
+	return m
+}
+
+func mergeFilters(dst, src bson.M) {
+	for k, v := range src {
+		dst[k] = v
+	}
+}
+
+type Query struct {
+	col   *mgo.Collection
+	limit int
+	query bson.M
+}
+
+func (q *Query) WithFields(filters ...nosql.FieldFilter) nosql.Query {
+	m := buildFilters(filters)
+	if q.query == nil {
+		q.query = m
+	} else {
+		mergeFilters(q.query, m)
+	}
+	return q
+}
+func (q *Query) Limit(n int) nosql.Query {
+	q.limit = n
+	return q
+}
+func (q *Query) build() *mgo.Query {
+	var m interface{}
+	if q.query != nil {
+		m = q.query
+	}
+	qu := q.col.Find(m)
+	if q.limit > 0 {
+		qu = qu.Limit(q.limit)
+	}
+	return qu
+}
+func (q *Query) Count(ctx context.Context) (int64, error) {
+	n, err := q.build().Count()
+	return int64(n), err
+}
+func (q *Query) One(ctx context.Context) (nosql.Document, error) {
+	var m bson.M
+	err := q.build().One(&m)
+	if err == mgo.ErrNotFound {
+		return nil, nosql.ErrNotFound
+	} else if err != nil {
+		return nil, err
+	}
+	return convRootDoc(m), nil
+}
+func (q *Query) Iterate() nosql.DocIterator {
+	it := q.build().Iter()
+	return &Iterator{it: it}
+}
+
+type Iterator struct {
+	it  *mgo.Iter
+	res bson.M
+}
+
+func (it *Iterator) Next(ctx context.Context) bool {
+	it.res = make(bson.M)
+	return it.it.Next(&it.res)
+}
+func (it *Iterator) Err() error {
+	return it.it.Err()
+}
+func (it *Iterator) Close() error {
+	return it.it.Close()
+}
+func (it *Iterator) ID() string {
+	s, _ := fromBsonValue(it.res[idField]).(nosql.String)
+	return string(s)
+}
+func (it *Iterator) Doc() nosql.Document {
+	return convRootDoc(it.res)
+}
+
+type Delete struct {
+	col   *mgo.Collection
+	query bson.M
+}
+
+func (d *Delete) WithFields(filters ...nosql.FieldFilter) nosql.Delete {
+	m := buildFilters(filters)
+	if d.query == nil {
+		d.query = m
+	} else {
+		mergeFilters(d.query, m)
+	}
+	return d
+}
+func (d *Delete) IDs(ids ...string) nosql.Delete {
+	if len(ids) == 0 {
+		return d
+	}
+	m := make(bson.M, 1)
+	if len(ids) == 1 {
+		m[idField] = ids[0]
+	} else {
+		m[idField] = bson.M{"$in": ids}
+	}
+	if d.query == nil {
+		d.query = m
+	} else {
+		mergeFilters(d.query, m)
+	}
+	return d
+}
+func (d *Delete) Do(ctx context.Context) error {
+	var qu interface{}
+	if d.query != nil {
+		qu = d.query
+	}
+	_, err := d.col.RemoveAll(qu)
+	return err
+}
+
+type Update struct {
+	col    *mgo.Collection
+	id     string
+	upsert bson.M
+	update bson.M
+}
+
+func (u *Update) Inc(field string, dn int) nosql.Update {
+	inc, _ := u.update["$inc"].(bson.M)
+	if inc == nil {
+		inc = make(bson.M)
+	}
+	inc[field] = dn
+	u.update["$inc"] = inc
+	return u
+}
+func (u *Update) Push(field string, v nosql.Value) nosql.Update {
+	push, _ := u.update["$push"].(bson.M)
+	if push == nil {
+		push = make(bson.M)
+	}
+	push[field] = toBsonValue(v)
+	u.update["$push"] = push
+	return u
+}
+func (u *Update) Upsert(d nosql.Document) nosql.Update {
+	u.upsert = toBsonDoc(d)
+	if u.upsert == nil {
+		u.upsert = make(bson.M)
+	}
+	return u
+}
+func (u *Update) Do(ctx context.Context) error {
+	var err error
+	if u.upsert != nil {
+		if len(u.upsert) != 0 {
+			u.update["$setOnInsert"] = u.upsert
+		}
+		_, err = u.col.UpsertId(u.id, u.update)
+	} else {
+		err = u.col.UpdateId(u.id, u.update)
+	}
+	return err
+}

--- a/graph/nosql/mongo/mongo_test.go
+++ b/graph/nosql/mongo/mongo_test.go
@@ -1,0 +1,39 @@
+// +build docker
+
+package mongo
+
+import (
+	"testing"
+
+	"github.com/cayleygraph/cayley/graph"
+	"github.com/cayleygraph/cayley/graph/nosql"
+	"github.com/cayleygraph/cayley/graph/nosql/nosqltest"
+	"github.com/cayleygraph/cayley/internal/dock"
+)
+
+func makeMongo(t testing.TB) (nosql.Database, graph.Options, func()) {
+	var conf dock.Config
+
+	conf.Image = "mongo:3"
+	conf.OpenStdin = true
+	conf.Tty = true
+
+	addr, closer := dock.Run(t, conf)
+
+	addr = addr + ":27017"
+	qs, err := dialDB(addr, nil)
+	if err != nil {
+		closer()
+		t.Fatal(err)
+	}
+	return qs, nil, func() {
+		qs.Close()
+		closer()
+	}
+}
+
+func TestMongoAll(t *testing.T) {
+	nosqltest.TestAll(t, makeMongo, &nosqltest.Config{
+		TimeInMs: true,
+	})
+}

--- a/graph/nosql/nosql.go
+++ b/graph/nosql/nosql.go
@@ -6,24 +6,24 @@ import (
 	"time"
 )
 
-const (
-	IDField = "id"
-)
-
 var (
 	ErrNotFound = errors.New("not found")
 )
 
+type Key []string
+
+func (Key) isValue() {}
+
 type Database interface {
-	Insert(col string, id string, d Document) (string, error)
-	FindByID(col string, id string) (Document, error)
+	Insert(col string, key Key, d Document) (Key, error)
+	FindByKey(col string, key Key) (Document, error)
 	Query(col string) Query
-	Update(col string, id string) Update
+	Update(col string, key Key) Update
 	Delete(col string) Delete
 	// EnsureIndex
 	//
 	// Should create collection if it not exists
-	EnsureIndex(col string, indexes ...Index) error
+	EnsureIndex(col string, primary Index, secondary []Index) error
 	Close() error
 }
 
@@ -63,7 +63,7 @@ type Update interface {
 
 type Delete interface {
 	WithFields(filters ...FieldFilter) Delete
-	IDs(ids ...string) Delete
+	Keys(keys ...Key) Delete
 	Do(ctx context.Context) error
 }
 
@@ -71,7 +71,7 @@ type DocIterator interface {
 	Next(ctx context.Context) bool
 	Err() error
 	Close() error
-	ID() string
+	Key() Key
 	Doc() Document
 }
 
@@ -87,8 +87,8 @@ const (
 )
 
 type Index struct {
-	Field string
-	Type  IndexType
+	Fields []string
+	Type   IndexType
 }
 
 type Value interface {

--- a/graph/nosql/nosql.go
+++ b/graph/nosql/nosql.go
@@ -56,7 +56,6 @@ type Query interface {
 type Update interface {
 	//Set(d Document) Update
 	Inc(field string, dn int) Update
-	Push(field string, v Value) Update
 	Upsert(d Document) Update
 	Do(ctx context.Context) error
 }

--- a/graph/nosql/nosql.go
+++ b/graph/nosql/nosql.go
@@ -1,0 +1,128 @@
+package nosql
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+const (
+	IDField = "id"
+)
+
+var (
+	ErrNotFound = errors.New("not found")
+)
+
+type Database interface {
+	Insert(col string, id string, d Document) (string, error)
+	FindByID(col string, id string) (Document, error)
+	Query(col string) Query
+	Update(col string, id string) Update
+	Delete(col string) Delete
+	// EnsureIndex
+	//
+	// Should create collection if it not exists
+	EnsureIndex(col string, indexes ...Index) error
+	Close() error
+}
+
+type Filter int
+
+const (
+	Equal = Filter(iota)
+	NotEqual
+	GT
+	GTE
+	LT
+	LTE
+)
+
+type FieldFilter struct {
+	Path   []string
+	Filter Filter
+	Value  Value
+}
+
+type Query interface {
+	WithFields(filters ...FieldFilter) Query
+	Limit(n int) Query
+
+	Count(ctx context.Context) (int64, error)
+	One(ctx context.Context) (Document, error)
+	Iterate() DocIterator
+}
+
+type Update interface {
+	//Set(d Document) Update
+	Inc(field string, dn int) Update
+	Push(field string, v Value) Update
+	Upsert(d Document) Update
+	Do(ctx context.Context) error
+}
+
+type Delete interface {
+	WithFields(filters ...FieldFilter) Delete
+	IDs(ids ...string) Delete
+	Do(ctx context.Context) error
+}
+
+type DocIterator interface {
+	Next(ctx context.Context) bool
+	Err() error
+	Close() error
+	ID() string
+	Doc() Document
+}
+
+type IndexType int
+
+const (
+	IndexAny = IndexType(iota)
+	StringExact
+	StringFulltext
+	IntIndex
+	FloatIndex
+	TimeIndex
+)
+
+type Index struct {
+	Field string
+	Type  IndexType
+}
+
+type Value interface {
+	isValue()
+}
+
+type Document map[string]Value
+
+func (Document) isValue() {}
+
+type String string
+
+func (String) isValue() {}
+
+type Int int64
+
+func (Int) isValue() {}
+
+type Float float64
+
+func (Float) isValue() {}
+
+type Bool bool
+
+func (Bool) isValue() {}
+
+type Time time.Time
+
+func (Time) isValue() {}
+
+type Bytes []byte
+
+func (Bytes) isValue() {}
+
+type Array []Value
+
+func (Array) isValue() {}

--- a/graph/nosql/nosqltest/nosqltest.go
+++ b/graph/nosql/nosqltest/nosqltest.go
@@ -1,0 +1,152 @@
+package nosqltest
+
+import (
+	"bytes"
+	"math/rand"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cayleygraph/cayley/graph"
+	"github.com/cayleygraph/cayley/graph/graphtest"
+	"github.com/cayleygraph/cayley/graph/nosql"
+	"github.com/cayleygraph/cayley/graph/path/pathtest"
+	"github.com/cayleygraph/cayley/quad"
+)
+
+type DatabaseFunc func(t testing.TB) (nosql.Database, graph.Options, func())
+
+type Config struct {
+	TimeInMs bool
+}
+
+func (c Config) quadStore() *graphtest.Config {
+	return &graphtest.Config{
+		NoPrimitives:             true,
+		TimeInMs:                 c.TimeInMs,
+		OptimizesComparison:      true,
+		SkipDeletedFromIterator:  true,
+		SkipSizeCheckAfterDelete: true,
+	}
+}
+
+func NewQuadStore(t testing.TB, gen DatabaseFunc) (graph.QuadStore, graph.Options, func()) {
+	db, opt, closer := gen(t)
+	err := nosql.Init(db, opt)
+	if err != nil {
+		db.Close()
+		closer()
+		require.Fail(t, "init failed", "%v", err)
+	}
+	kdb, err := nosql.New(db, opt)
+	if err != nil {
+		db.Close()
+		closer()
+		require.Fail(t, "create failed", "%v", err)
+	}
+	return kdb, opt, func() {
+		kdb.Close()
+		closer()
+	}
+}
+
+const parallel = false
+
+func TestAll(t *testing.T, gen DatabaseFunc, conf *Config) {
+	if conf == nil {
+		conf = &Config{}
+	}
+	t.Run("qs", func(t *testing.T) {
+		if parallel {
+			t.Parallel()
+		}
+		graphtest.TestAll(t, func(t testing.TB) (graph.QuadStore, graph.Options, func()) {
+			return NewQuadStore(t, gen)
+		}, conf.quadStore())
+	})
+	t.Run("paths", func(t *testing.T) {
+		if parallel {
+			t.Parallel()
+		}
+		pathtest.RunTestMorphisms(t, func(t testing.TB) (graph.QuadStore, graph.Options, func()) {
+			return NewQuadStore(t, gen)
+		})
+	})
+	t.Run("concurrent", func(t *testing.T) {
+		if testing.Short() {
+			t.SkipNow()
+		}
+		t.SkipNow()
+		if parallel {
+			t.Parallel()
+		}
+		testConcurrent(t, gen)
+	})
+}
+
+func randString() string {
+	const n = 60
+	b := bytes.NewBuffer(nil)
+	b.Grow(n)
+	for i := 0; i < n; i++ {
+		b.WriteByte(byte('a' + rand.Intn(26)))
+	}
+	return b.String()
+}
+
+func testConcurrent(t testing.TB, gen DatabaseFunc) {
+	qs, opts, closer := NewQuadStore(t, gen)
+	defer closer()
+	if opts == nil {
+		opts = make(graph.Options)
+	}
+	opts["ignore_duplicate"] = true
+	qw := graphtest.MakeWriter(t, qs, opts)
+
+	const n = 1000
+	subjects := make([]string, 0, n/4)
+	for i := 0; i < cap(subjects); i++ {
+		subjects = append(subjects, randString())
+	}
+	var wg sync.WaitGroup
+	wg.Add(2)
+	done := make(chan struct{})
+	go func() {
+		defer wg.Done()
+		defer close(done)
+		for i := 0; i < n; i++ {
+			n1 := subjects[rand.Intn(len(subjects))]
+			n2 := subjects[rand.Intn(len(subjects))]
+			t := graph.NewTransaction()
+			t.AddQuad(quad.Make(n1, "link", n2, nil))
+			t.AddQuad(quad.Make(n2, "link", n1, nil))
+			if err := qw.ApplyTransaction(t); err != nil {
+				panic(err)
+			}
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-done:
+				return
+			default:
+			}
+			n1 := subjects[rand.Intn(len(subjects))]
+			it := qs.QuadIterator(quad.Subject, qs.ValueOf(quad.String(n1)))
+			for it.Next() {
+				q := qs.Quad(it.Result())
+				_ = q.Subject.Native()
+				_ = q.Predicate.Native()
+				_ = q.Object.Native()
+			}
+			if err := it.Close(); err != nil {
+				panic(err)
+			}
+		}
+	}()
+	wg.Wait()
+}

--- a/graph/nosql/ouch/README.md
+++ b/graph/nosql/ouch/README.md
@@ -5,7 +5,7 @@ Also need to "npm install pouchdb-find" for queries.
 When running "gopherjs test" from the ouch directory, a pouchdb.test directory will be created (in .gitignore).
 
 
-To run "go test" a publiclly accessable CouchDB must be at "http://127.0.0.1:5984/ouchtest"
+To run "go test" a publiclly accessable CouchDB must be at "http://127.0.0.1:5984/ouchtest" with an administrator account testusername:testpassword (basic auth only, as this also works from the browser).
 
 Note from Discussion forum, re future nosql API alterations at https://discourse.cayley.io/t/running-cayley-in-the-browser/960/13
 

--- a/graph/nosql/ouch/README.md
+++ b/graph/nosql/ouch/README.md
@@ -1,0 +1,9 @@
+# Ouch, prototype driver for CouchDB/PouchDB
+
+To run "gopherjs test -v" you must "npm install pouchdb" (which actually runs on top of levelDB when not in memory mode) 
+
+
+Note from Discussion forum, re future nosql API alterations at https://discourse.cayley.io/t/running-cayley-in-the-browser/960/13
+
+* I suggest that all the Database interface methods have context as the first parameter, and that context is removed from all the "child" methods (like Query.One).
+* Reply from dennwc37: This might not work well for DocIterator - it might be passed around and should use the context of the last caller, not the first one. I would say it make sense we can add contexts to Insert, FindByKey and EnsureIndexes and leave other builders as-is, since they already pass context in Do, One, Next, etc.

--- a/graph/nosql/ouch/README.md
+++ b/graph/nosql/ouch/README.md
@@ -11,3 +11,13 @@ Note from Discussion forum, re future nosql API alterations at https://discourse
 
 * I suggest that all the Database interface methods have context as the first parameter, and that context is removed from all the "child" methods (like Query.One).
 * Reply from dennwc37: This might not work well for DocIterator - it might be passed around and should use the context of the last caller, not the first one. I would say it make sense we can add contexts to Insert, FindByKey and EnsureIndexes and leave other builders as-is, since they already pass context in Do, One, Next, etc.
+
+## TODO
+
+* fix bugs reported by TestAll
+* fix "KK" bug in Delete.Keys()
+* work out how to delete test db remotely from JS using PouchDB as front-end to CouchDB
+* add indexing
+* optimize ID field to be simple string
+* only pull back the _id & _ref fields in the delete query
+	

--- a/graph/nosql/ouch/README.md
+++ b/graph/nosql/ouch/README.md
@@ -1,7 +1,9 @@
 # Ouch, prototype driver for CouchDB/PouchDB
 
-To run "gopherjs test -v" you must "npm install pouchdb" (which actually runs on top of levelDB when not in memory mode) 
+To run "gopherjs test -v" you must "npm install pouchdb" (which actually runs on top of levelDB). 
+When running "gopherjs test" from the ouch directory, a pouchdb.test directory will be created (in .gitignore).
 
+To run "go test" a publiclly accessable CouchDB must be at "http://127.0.0.1:5984/ouchtest"
 
 Note from Discussion forum, re future nosql API alterations at https://discourse.cayley.io/t/running-cayley-in-the-browser/960/13
 

--- a/graph/nosql/ouch/README.md
+++ b/graph/nosql/ouch/README.md
@@ -1,7 +1,9 @@
 # Ouch, prototype driver for CouchDB/PouchDB
 
 To run "gopherjs test -v" you must "npm install pouchdb" (which actually runs on top of levelDB). 
+Also need to "npm install pouchdb-find" for queries.
 When running "gopherjs test" from the ouch directory, a pouchdb.test directory will be created (in .gitignore).
+
 
 To run "go test" a publiclly accessable CouchDB must be at "http://127.0.0.1:5984/ouchtest"
 

--- a/graph/nosql/ouch/backend.go
+++ b/graph/nosql/ouch/backend.go
@@ -1,0 +1,9 @@
+// +build !js
+
+package ouch
+
+import (
+	_ "github.com/go-kivik/couchdb" // The CouchDB driver
+)
+
+var defaultDriverName = "couch"

--- a/graph/nosql/ouch/backend_js.go
+++ b/graph/nosql/ouch/backend_js.go
@@ -1,0 +1,9 @@
+// +build js
+
+package ouch
+
+import (
+	_ "github.com/go-kivik/pouchdb" // The PouchDB driver
+)
+
+var defaultDriverName = "pouch"

--- a/graph/nosql/ouch/debug.go
+++ b/graph/nosql/ouch/debug.go
@@ -1,0 +1,111 @@
+package ouch
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/cayleygraph/cayley/graph/nosql"
+)
+
+func (db *DB) dcheck(key nosql.Key, d nosql.Document) error {
+	col := string(d[collectionField].(nosql.String))
+	decoded, err := db.FindByKey(col, key)
+
+	if err != nil {
+		return fmt.Errorf("unable to find record to check FindByKey '%v' error: %v", key, err)
+	}
+
+	return dcompare(decoded, d)
+}
+
+func dcompare(decoded, d nosql.Document) error {
+	for k, v := range decoded {
+		if k != "_rev" { // _ fields should have changed
+			switch x := v.(type) {
+			case nosql.Document:
+				if err := dcompare(d[k].(nosql.Document), x); err != nil {
+					return err
+				}
+			case nosql.Key:
+				for i, kv := range x {
+					if d[k].(nosql.Key)[i] != kv {
+						return fmt.Errorf("decoded key %s not-equal original %v", k)
+					}
+				}
+			case nosql.Bytes:
+				for i, kv := range x {
+					if d[k].(nosql.Bytes)[i] != kv {
+						return fmt.Errorf("bytes %s not-equal", k)
+					}
+				}
+			case nosql.Array:
+				_, ok := d[k].(nosql.Array)
+				if !ok {
+					return fmt.Errorf("decoded array not-equal original %s %v %T %v %T", k, v, v, d[k], d[k])
+				}
+				// check contents of arrays
+				for i, kv := range x {
+					if err := dcompare(
+						nosql.Document{k: d[k].(nosql.Array)[i]},
+						nosql.Document{k: kv},
+					); err != nil {
+						return err
+					}
+				}
+			case nosql.Time:
+				if !time.Time(d[k].(nosql.Time)).Equal(time.Time(x)) {
+					return fmt.Errorf("decoded Time value not-equal original %s %v %T %v %T", k, v, v, d[k], d[k])
+				}
+			default:
+				if d[k] != v {
+					return fmt.Errorf("decoded value not-equal original %s %v %T %v %T", k, v, v, d[k], d[k])
+				}
+			}
+		}
+	}
+	for k, v := range d {
+		if k[0] != '_' { // _ fields should have changed
+			switch x := v.(type) {
+			case nosql.Document:
+				if err := dcompare(x, decoded[k].(nosql.Document)); err != nil {
+					return err
+				}
+			case nosql.Bytes:
+				for i, kv := range x {
+					if decoded[k].(nosql.Bytes)[i] != kv {
+						return fmt.Errorf("bytes %s not-equal", k)
+					}
+				}
+			case nosql.Key:
+				for i, kv := range x {
+					if decoded[k].(nosql.Key)[i] != kv {
+						return fmt.Errorf("keys %s not-equal", k)
+					}
+				}
+			case nosql.Array: // TODO
+				_, ok := decoded[k].(nosql.Array)
+				if !ok {
+					return fmt.Errorf("array not-equal %s %v %T %v %T", k, v, v, decoded[k], decoded[k])
+				}
+				for i, kv := range x {
+					if err := dcompare(
+						nosql.Document{k: decoded[k].(nosql.Array)[i]},
+						nosql.Document{k: kv},
+					); err != nil {
+						return err
+					}
+				}
+			case nosql.Time:
+				if !time.Time(decoded[k].(nosql.Time)).Equal(time.Time(x)) {
+					return fmt.Errorf("Time value not-equal %s %v %T %v %T", k, v, v, d[k], d[k])
+				}
+
+			default:
+				if decoded[k] != v {
+					return fmt.Errorf("value not-equal %s %v %T %v %T", k, v, v, decoded[k], decoded[k])
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/graph/nosql/ouch/ouch.go
+++ b/graph/nosql/ouch/ouch.go
@@ -1,0 +1,532 @@
+package ouch
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/cayleygraph/cayley/graph"
+	"github.com/cayleygraph/cayley/graph/nosql"
+
+	"github.com/flimzy/kivik"
+)
+
+// DEBUG panic or trace
+func dpanic(s string) {
+	println(s)
+}
+
+// DEBUG check stored document is what we expect
+func (db *DB) dcheck(key nosql.Key, d nosql.Document) {
+	col := string(d[collectionField].(nosql.String))
+	decoded, err := db.FindByKey(col, key)
+
+	if err != nil {
+		fmt.Println("DEBUG FindByKey '", key, "' error:", err)
+		return
+	}
+
+	dcompare(decoded, d)
+}
+func dcompare(decoded, d nosql.Document) {
+	// 	decoded, reflect.DeepEqual(decoded, d))
+	for k, v := range decoded {
+		if k[0] != '_' { // _ fields should have changed
+			switch x := v.(type) {
+			case nosql.Document:
+				dcompare(d[k].(nosql.Document), x)
+			case nosql.Key:
+				for i, kv := range x {
+					if d[k].(nosql.Key)[i] != kv {
+						fmt.Printf("DEBUG decoded key %s not-equal\n", k)
+					}
+				}
+			default:
+				if d[k] != v {
+					fmt.Printf("DEBUG decoded not-equal %s %v %T %v %T\n", k, v, v, d[k], d[k])
+				}
+			}
+		}
+	}
+	for k, v := range d {
+		if k[0] != '_' { // _ fields should have changed
+			switch x := v.(type) {
+			case nosql.Document:
+				dcompare(x, decoded[k].(nosql.Document))
+			case nosql.Key:
+				for i, kv := range x {
+					if decoded[k].(nosql.Key)[i] != kv {
+						fmt.Printf("DEBUG k key %s not-equal\n", k)
+					}
+				}
+			default:
+				if decoded[k] != v {
+					fmt.Printf("DEBUG d not-equal %s %v %T %v %T\n", k, v, v, decoded[k], decoded[k])
+				}
+			}
+		}
+	}
+}
+
+const Type = "ouch"
+
+func init() {
+	nosql.Register(Type, nosql.Registration{
+		NewFunc:      Open,
+		InitFunc:     Create,
+		IsPersistent: true,
+	})
+}
+
+func dialDB(create bool, addr string, opt graph.Options) (*DB, error) {
+
+	driver := defaultDriverName
+	// if drivOpt, exists, err := opt.StringKey("driver"); exists {
+	// 	driver = drivOpt
+	// } else {
+	// 	if err != nil {
+	// 		return nil, err
+	// 	}
+	// }
+	fmt.Println("DEBUG dialDB", driver, create, addr, opt)
+
+	addrParsed, err := url.Parse(addr)
+	if err != nil {
+		return nil, err
+	}
+
+	pathParts := strings.Split(addrParsed.Path, "/")
+	dbName := "cayleygraph"
+	if len(pathParts) > 0 && addr != "" {
+		dbName = pathParts[len(pathParts)-1]
+	}
+	dsn := strings.TrimSuffix(addr, dbName)
+
+	client, err := kivik.New(context.TODO(), driver, dsn)
+	if err != nil {
+		return nil, err
+	}
+
+	if create {
+		err := client.CreateDB(context.TODO(), dbName)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	db, err := client.DB(context.TODO(), dbName)
+	if err != nil {
+		return nil, err
+	}
+
+	return &DB{
+		db:     db,
+		colls:  make(map[string]collection),
+		driver: driver,
+	}, nil
+}
+
+func Create(addr string, opt graph.Options) (nosql.Database, error) {
+	return dialDB(true, addr, opt)
+}
+
+func Open(addr string, opt graph.Options) (nosql.Database, error) {
+	create := false
+	if opt["driver"] == "memory" { // a blank database, intended for testing
+		create = true
+	}
+	return dialDB(create, addr, opt)
+}
+
+type collection struct {
+	//TODO!
+	compPK    bool // compose PK from existing keys; if false, use _id instead of target field
+	primary   nosql.Index
+	secondary []nosql.Index
+}
+
+type DB struct {
+	db     *kivik.DB
+	colls  map[string]collection
+	driver string
+}
+
+func (db *DB) Close() error {
+	// seems no way to close a kivik session, so just let the go garbage collection do its stuff...
+	db.db = nil
+	db.colls = nil
+	return nil
+}
+
+func (db *DB) EnsureIndex(col string, primary nosql.Index, secondary []nosql.Index) error {
+	if primary.Type != nosql.StringExact {
+		return fmt.Errorf("unsupported type of primary index: %v", primary.Type)
+	}
+	fmt.Println("DEBUG DB.EnsureIndex", col, primary, secondary)
+	if db.driver != "memory" { // the memory driver does not implement this functionality
+		panic("DB.EnsureIndex")
+	}
+	return nil
+
+}
+
+func toInterfaceValue(k string, v nosql.Value) (string, interface{}) {
+	switch v := v.(type) {
+	case nil:
+		return k, nil
+	case nosql.Document:
+		return k, toInterfaceDoc(v)
+	case nosql.Array:
+		arr := make([]interface{}, 0, len(v))
+		for _, s := range v {
+			_, newVal := toInterfaceValue(k, s)
+			arr = append(arr, newVal)
+		}
+		return k, arr
+	case nosql.Key: // special handling here, as type can't be inferred from json
+		arr := make([]interface{}, 0, len(v))
+		for _, s := range v {
+			arr = append(arr, s) // string
+		}
+		return k + "$Key", arr
+	case nosql.String:
+		return k, string(v)
+	case nosql.Int:
+		return k + "$Int", int64(v)
+	case nosql.Float:
+		return k, float64(v)
+	case nosql.Bool:
+		return k, bool(v)
+	case nosql.Time:
+		return k, time.Time(v)
+	case nosql.Bytes:
+		return k, []byte(v)
+	default:
+		panic(fmt.Errorf("unsupported type: %T", v))
+	}
+}
+
+func toInterfaceDoc(d nosql.Document) map[string]interface{} {
+	if d == nil {
+		return nil
+	}
+	m := make(map[string]interface{})
+	for k, v := range d {
+		newK, newV := toInterfaceValue(k, v)
+		m[newK] = newV
+	}
+	return m
+}
+
+func fromInterfaceValue(k string, v interface{}) (string, nosql.Value) {
+	switch v := v.(type) {
+	case nil:
+		return k, nil
+	case map[string]interface{}:
+		return k, fromInterfaceDoc(v)
+	case []interface{}:
+		if strings.HasSuffix(k, "$Key") {
+			arr := make(nosql.Key, 0, len(v))
+			for _, s := range v {
+				arr = append(arr, s.(string))
+			}
+			return strings.TrimSuffix(k, "$Key"), arr
+		}
+		arr := make(nosql.Array, 0, len(v))
+		for _, s := range v {
+			_, newV := fromInterfaceValue(k, s)
+			arr = append(arr, newV)
+		}
+		return k, arr
+	case string:
+		return k, nosql.String(v)
+	case int:
+		return k, nosql.Int(v)
+	case int64:
+		return k, nosql.Int(v)
+	case float64:
+		if strings.HasSuffix(k, "$Int") {
+			return strings.TrimSuffix(k, "$Int"), nosql.Int(v)
+		}
+		return k, nosql.Float(v)
+	case bool:
+		return k, nosql.Bool(v)
+	case time.Time:
+		return k, nosql.Time(v)
+	case []byte:
+		return k, nosql.Bytes(v)
+	default:
+		panic(fmt.Errorf("unsupported type: %T", v))
+	}
+}
+
+func fromInterfaceDoc(d map[string]interface{}) nosql.Document {
+	if d == nil {
+		return nil
+	}
+	m := make(nosql.Document, len(d))
+	for k, v := range d {
+		newK, newV := fromInterfaceValue(k, v)
+		m[newK] = newV
+	}
+	return m
+}
+
+const idField = "_id"
+const collectionField = "$Collection"
+
+func compKey(key []string) string {
+	return strings.Join(key, "")
+}
+
+func (db *DB) Insert(col string, key nosql.Key, d nosql.Document) (nosql.Key, error) {
+	dpanic("DB.Insert")
+
+	fmt.Println("DEBUG INSERT", col, key)
+	fmt.Printf("doc: %#v\n", d)
+
+	if d == nil {
+		return nil, errors.New("no document to insert")
+	}
+	d[collectionField] = nosql.String(col)
+
+	cK := compKey(key)
+	if cK != "" {
+		d[idField] = nosql.String(cK)
+	}
+
+	interfaceDoc := toInterfaceDoc(d)
+
+	ouchID, _, err := db.db.CreateDoc(context.TODO(), interfaceDoc)
+	if err != nil {
+		return nil, err
+	}
+
+	if cK == "" {
+		key = nosql.Key([]string{ouchID}) // key auto-created
+		fmt.Println("DEBUG Created:", key)
+	}
+	db.dcheck(key, d)
+
+	return key, nil
+}
+
+func (db *DB) FindByKey(col string, key nosql.Key) (nosql.Document, error) {
+	dpanic("DB.FindByKey")
+
+	cK := compKey(key)
+
+	row, err := db.db.Get(context.TODO(), cK)
+	if err != nil {
+		fmt.Println("DEBUG", col, key, "NOT FOUND")
+		return nil, nosql.ErrNotFound
+		//return nil, err
+	}
+
+	rowDoc := make(map[string]interface{})
+	err = row.ScanDoc(&rowDoc)
+	if err != nil {
+		return nil, err
+	}
+	decoded := fromInterfaceDoc(rowDoc)
+
+	fmt.Println("DEBUG", col, key, "FOUND", decoded)
+
+	return decoded, nil
+}
+
+func (db *DB) Query(col string) nosql.Query {
+	dpanic("DB.Query")
+	return &Query{col: col}
+}
+func (db *DB) Update(col string, key nosql.Key) nosql.Update {
+	dpanic("DB.Update")
+	fmt.Println("DEBUG ", col, key)
+	return &Update{db: db, col: col, key: key, update: nosql.Document{
+		collectionField: nosql.String(col),
+	}}
+}
+func (db *DB) Delete(col string) nosql.Delete {
+	dpanic("DB.Delete")
+
+	return &Delete{col: col}
+}
+
+type Query struct {
+	col   string
+	limit int
+	//query TODO
+	//filters TODO
+}
+
+func (q *Query) WithFields(filters ...nosql.FieldFilter) nosql.Query {
+	panic("Query.WithFields")
+	return q
+}
+func (q *Query) Limit(n int) nosql.Query {
+	dpanic("Query.Limit")
+
+	q.limit = n
+	return q
+}
+
+func (q *Query) Count(ctx context.Context) (int64, error) {
+	panic("Query.Count")
+
+	return 0, nil
+}
+func (q *Query) One(ctx context.Context) (nosql.Document, error) {
+	panic("Query.One")
+
+	return nil, nil
+}
+func (q *Query) Iterate() nosql.DocIterator {
+	panic("Query.Iterate")
+
+	return &Iterator{}
+}
+
+type Iterator struct {
+	c *collection
+}
+
+func (it *Iterator) Next(ctx context.Context) bool {
+	panic("Iterator.Next")
+	return false
+}
+func (it *Iterator) Err() error {
+	panic("Iterator.Err")
+	return nil
+}
+func (it *Iterator) Close() error {
+	panic("Iterator.Close")
+	return nil
+}
+func (it *Iterator) Key() nosql.Key {
+	panic("Iterator.Key")
+	return nil
+}
+func (it *Iterator) Doc() nosql.Document {
+	panic("Iterator.Doc")
+	return nil
+}
+
+type Delete struct {
+	col string
+	// query TODO
+}
+
+func (d *Delete) WithFields(filters ...nosql.FieldFilter) nosql.Delete {
+	panic("Delete.WithFields")
+	return nil
+}
+func (d *Delete) Keys(keys ...nosql.Key) nosql.Delete {
+	panic("Delete.Keys")
+	return nil
+}
+func (d *Delete) Do(ctx context.Context) error {
+	panic("Delete.Do")
+	return nil
+}
+
+type Update struct {
+	db     *DB
+	col    string
+	key    nosql.Key
+	update nosql.Document
+	upsert bool
+	inc    map[string]int // is this the required logic???
+	push   map[string]nosql.Value
+}
+
+func (u *Update) Inc(field string, dn int) nosql.Update {
+	dpanic("Update.Inc")
+	fmt.Println(field, dn)
+	if u.inc == nil {
+		u.inc = make(map[string]int)
+	}
+	u.inc[field] += dn
+	return u
+}
+
+func (u *Update) Push(field string, v nosql.Value) nosql.Update {
+	dpanic("Update.Push")
+	fmt.Println("DEBUG", field, v)
+	u.push[field] = v
+	return u
+}
+func (u *Update) Upsert(d nosql.Document) nosql.Update {
+	dpanic("Update.Upsert")
+	fmt.Println("DEBUG", d)
+	u.upsert = true
+	for k, v := range d {
+		u.update[k] = v
+	}
+	return u
+}
+func (u *Update) Do(ctx context.Context) error {
+	dpanic("Update.Do")
+	col := ""
+	if c, ok := u.update[collectionField]; ok {
+		if cs, ok := c.(nosql.String); ok {
+			col = string(cs)
+		}
+	}
+	if col == "" {
+		return errors.New("no collection name")
+	}
+
+	orig, err := u.db.FindByKey(col, u.key)
+	if err == nosql.ErrNotFound {
+		if !u.upsert {
+			return err
+		} else {
+			orig = u.update
+			_, err = u.db.Insert(col, u.key, orig)
+			if err != nil {
+				return err
+			}
+			orig, err = u.db.FindByKey(col, u.key) // to get the correct "_rev" - TODO make more efficient!
+			if err != nil {
+				return err
+			}
+		}
+	} else {
+		return err
+	}
+
+	for k, v := range u.update {
+		orig[k] = v
+	}
+
+	for k, v := range u.push { // TODO is this right?
+		orig[k] = v
+	}
+
+	for k, v := range u.inc { // TODO is this right?
+		val, exists := orig[k]
+		if exists {
+			switch x := val.(type) {
+			case nosql.Int:
+				val = nosql.Int(int64(x) + int64(v))
+			default:
+				return errors.New("field '" + k + "' is not an integer")
+			}
+		} else {
+			val = nosql.Int(v)
+		}
+		orig[k] = val
+	}
+
+	_, err = u.db.db.Put(context.TODO(), compKey(u.key), toInterfaceDoc(orig))
+	if err != nil {
+		return err
+	}
+
+	u.db.dcheck(u.key, orig)
+
+	return err
+}

--- a/graph/nosql/ouch/ouch.go
+++ b/graph/nosql/ouch/ouch.go
@@ -56,9 +56,11 @@ func dialDB(create bool, addr string, opt graph.Options) (*DB, error) {
 	}
 
 	pathParts := strings.Split(addrParsed.Path, "/")
-	dbName := "cayleygraph"
+	dbName := ""
 	if len(pathParts) > 0 && addr != "" {
 		dbName = pathParts[len(pathParts)-1]
+	} else {
+		return nil, errors.New("unable to decypher database name from: " + addr)
 	}
 	dsn := strings.TrimSuffix(addr, dbName)
 
@@ -284,7 +286,9 @@ func (q *Query) Count(ctx context.Context) (int64, error) {
 	return count, nil
 }
 func (q *Query) One(ctx context.Context) (nosql.Document, error) {
-	panic("Query.One")
+	dpanic("Query.One")
+
+	//TODO!
 
 	return nil, nil
 }
@@ -351,7 +355,8 @@ type Delete struct {
 }
 
 func (d *Delete) WithFields(filters ...nosql.FieldFilter) nosql.Delete {
-	panic("Delete.WithFields")
+	dpanic("Delete.WithFields")
+	// TODO!
 	return d
 }
 func (d *Delete) Keys(keys ...nosql.Key) nosql.Delete {

--- a/graph/nosql/ouch/ouch_test.go
+++ b/graph/nosql/ouch/ouch_test.go
@@ -1,0 +1,169 @@
+package ouch
+
+import (
+	"fmt"
+	"log"
+	"testing"
+
+	_ "github.com/go-kivik/memorydb"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cayleygraph/cayley"
+	"github.com/cayleygraph/cayley/graph"
+	"github.com/cayleygraph/cayley/graph/nosql"
+	"github.com/cayleygraph/cayley/graph/nosql/nosqltest"
+	"github.com/cayleygraph/cayley/quad"
+	"github.com/cayleygraph/cayley/writer"
+)
+
+func testDB() string {
+	switch defaultDriverName {
+	case "memory":
+		return "ouchtest"
+	default:
+		panic("bad defaultDriverName: " + defaultDriverName)
+	}
+}
+
+func makeOuch(t testing.TB) (nosql.Database, graph.Options, func()) {
+	qs, err := dialDB(true, testDB(), graph.Options{
+		"driver": "memory",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return qs, nil, func() {
+		qs.Close()
+	}
+}
+
+func xTestOuchAll(t *testing.T) {
+	defaultDriverName = "memory" // for initial testing only
+	nosqltest.TestAll(t, makeOuch, &nosqltest.Config{
+		TimeInMs: true,
+	})
+}
+
+// TestMemstore does those tests possible using the memory backend (simple only)
+func TestMemstore(t *testing.T) {
+	defaultDriverName = "memory" // for testing only
+	dbc, err := Create(testDB(), graph.Options{})
+	if err != nil {
+		t.Error("DB create error", defaultDriverName, dbc, err)
+		return
+	}
+	err = dbc.Close()
+	if err != nil {
+		t.Error("DB close error", err)
+	}
+}
+
+func xTestHelloWorld(t *testing.T) {
+
+	defaultDriverName = "memory" // for initial testing only
+
+	store, err := cayley.NewGraph("ouch", testDB(), graph.Options{})
+	if err != nil {
+		panic(err)
+	}
+
+	store.AddQuad(quad.Make("phrase of the day", "is of course", "Hello World!", nil))
+
+	// Now we create the path, to get to our data
+	p := cayley.StartPath(store, quad.String("phrase of the day")).Out(quad.String("is of course"))
+
+	// Now we iterate over results. Arguments:
+	// 1. Optional context used for cancellation.
+	// 2. Flag to optimize query before execution.
+	// 3. Quad store, but we can omit it because we have already built path with it.
+	err = p.Iterate(nil).EachValue(nil, func(value quad.Value) {
+		nativeValue := quad.NativeOf(value) // this converts RDF values to normal Go types
+		fmt.Println(nativeValue)
+	})
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+}
+
+// below from the memstore tests
+
+// This is a simple test graph.
+//
+//    +---+                        +---+
+//    | A |-------               ->| F |<--
+//    +---+       \------>+---+-/  +---+   \--+---+
+//                 ------>|#B#|      |        | E |
+//    +---+-------/      >+---+      |        +---+
+//    | C |             /            v
+//    +---+           -/           +---+
+//      ----    +---+/             |#G#|
+//          \-->|#D#|------------->+---+
+//              +---+
+//
+var simpleGraph = []quad.Quad{
+	quad.MakeRaw("A", "follows", "B", ""),
+	quad.MakeRaw("C", "follows", "B", ""),
+	quad.MakeRaw("C", "follows", "D", ""),
+	quad.MakeRaw("D", "follows", "B", ""),
+	quad.MakeRaw("B", "follows", "F", ""),
+	quad.MakeRaw("F", "follows", "G", ""),
+	quad.MakeRaw("D", "follows", "G", ""),
+	quad.MakeRaw("E", "follows", "F", ""),
+	quad.MakeRaw("B", "status", "cool", "status_graph"),
+	quad.MakeRaw("D", "status", "cool", "status_graph"),
+	quad.MakeRaw("G", "status", "cool", "status_graph"),
+}
+
+func makeTestStore(data []quad.Quad) (graph.QuadStore, graph.QuadWriter, []pair) {
+	defaultDriverName = "memory" // for initial testing only
+
+	seen := make(map[string]struct{})
+	qs, err := graph.NewQuadStore("ouch", testDB(), graph.Options{})
+	if err != nil {
+		panic(err)
+	}
+	var (
+		val int64
+		ind []pair
+	)
+	writer, _ := writer.NewSingleReplication(qs, nil)
+	for _, t := range data {
+		for _, dir := range quad.Directions {
+			qp := t.GetString(dir)
+			if _, ok := seen[qp]; !ok && qp != "" {
+				val++
+				ind = append(ind, pair{qp, val})
+				seen[qp] = struct{}{}
+			}
+		}
+
+		writer.AddQuad(t)
+		val++
+	}
+	return qs, writer, ind
+}
+
+type pair struct {
+	query string
+	value int64
+}
+
+func xTestSimpleGraph(t *testing.T) {
+	qs, _, index := makeTestStore(simpleGraph)
+
+	t.Log(qs, index)
+
+	require.Equal(t, int64(22), qs.Size())
+
+	// TODO replicate
+	// for _, test := range index {
+	// 	v := qs.ValueOf(quad.Raw(test.query))
+	// 	switch v := v.(type) {
+	// 	default:
+	// 		t.Errorf("ValueOf(%q) returned unexpected type, got:%T expected int64", test.query, v)
+	// 	case bnode:
+	// 		require.Equal(t, test.value, int64(v))
+	// 	}
+	// }
+}

--- a/graph/nosql/ouch/ouch_test.go
+++ b/graph/nosql/ouch/ouch_test.go
@@ -139,7 +139,7 @@ func deleteAllOuchDocs(testDBname string) error {
 	defer rows.Close()
 
 	for rows.Next() {
-		fmt.Println("deleteAllOuchDocs", rows.ID())
+		//fmt.Println("deleteAllOuchDocs", rows.ID())
 		err = db.Delete("").Keys(nosql.Key{rows.ID()}).Do(context.TODO())
 		if err != nil {
 			return err
@@ -223,8 +223,8 @@ func TestHelloWorld(t *testing.T) {
 		return
 	}
 
-	trace = true
-	defer func() { trace = false }()
+	// trace = true
+	// defer func() { trace = false }()
 
 	store, err := cayley.NewGraph("ouch", dbName, graph.Options{})
 	if err != nil {
@@ -232,7 +232,8 @@ func TestHelloWorld(t *testing.T) {
 		return
 	}
 
-	err = store.AddQuad(quad.Make("phrase of the day", "is of course", "Hello World!", nil))
+	const helloWorld = "Hello World!"
+	err = store.AddQuad(quad.Make("phrase of the day", "is of course", helloWorld, nil))
 	if err != nil {
 		t.Error(err)
 		return
@@ -247,7 +248,10 @@ func TestHelloWorld(t *testing.T) {
 	// 3. Quad store, but we can omit it because we have already built path with it.
 	err = p.Iterate(nil).EachValue(nil, func(value quad.Value) {
 		nativeValue := quad.NativeOf(value) // this converts RDF values to normal Go types
-		fmt.Println(nativeValue)
+		//fmt.Println(nativeValue)
+		if nativeValue.(string) != helloWorld {
+			t.Errorf("NOT " + helloWorld)
+		}
 	})
 	if err != nil {
 		t.Error(err)

--- a/graph/nosql/ouch/ouch_test.go
+++ b/graph/nosql/ouch/ouch_test.go
@@ -3,6 +3,8 @@ package ouch
 import (
 	"fmt"
 	"log"
+	"math"
+	"sort"
 	"testing"
 	"time"
 
@@ -16,6 +18,100 @@ import (
 	"github.com/cayleygraph/cayley/quad"
 	"github.com/cayleygraph/cayley/writer"
 )
+
+func (db *DB) dcheck(key nosql.Key, d nosql.Document) error {
+	col := string(d[collectionField].(nosql.String))
+	decoded, err := db.FindByKey(col, key)
+
+	if err != nil {
+		return fmt.Errorf("unable to find record to check FindByKey '%v' error: %v", key, err)
+	}
+
+	return dcompare(decoded, d)
+}
+
+func dcompare(decoded, d nosql.Document) error {
+	for k, v := range decoded {
+		if k[0] != '_' { // _ fields should have changed
+			switch x := v.(type) {
+			case nosql.Document:
+				if err := dcompare(d[k].(nosql.Document), x); err != nil {
+					return err
+				}
+			case nosql.Key:
+				for i, kv := range x {
+					if d[k].(nosql.Key)[i] != kv {
+						return fmt.Errorf("decoded key %s not-equal original %v", k)
+					}
+				}
+			case nosql.Bytes:
+				for i, kv := range x {
+					if d[k].(nosql.Bytes)[i] != kv {
+						return fmt.Errorf("bytes %s not-equal", k)
+					}
+				}
+			case nosql.Array:
+				_, ok := d[k].(nosql.Array)
+				if !ok {
+					return fmt.Errorf("decoded array not-equal original %s %v %T %v %T", k, v, v, d[k], d[k])
+				}
+				// check contents of arrays
+				for i, kv := range x {
+					if err := dcompare(
+						nosql.Document{k: d[k].(nosql.Array)[i]},
+						nosql.Document{k: kv},
+					); err != nil {
+						return err
+					}
+				}
+			default:
+				if d[k] != v {
+					return fmt.Errorf("decoded value not-equal original %s %v %T %v %T", k, v, v, d[k], d[k])
+				}
+			}
+		}
+	}
+	for k, v := range d {
+		if k[0] != '_' { // _ fields should have changed
+			switch x := v.(type) {
+			case nosql.Document:
+				if err := dcompare(x, decoded[k].(nosql.Document)); err != nil {
+					return err
+				}
+			case nosql.Bytes:
+				for i, kv := range x {
+					if decoded[k].(nosql.Bytes)[i] != kv {
+						return fmt.Errorf("bytes %s not-equal", k)
+					}
+				}
+			case nosql.Key:
+				for i, kv := range x {
+					if decoded[k].(nosql.Key)[i] != kv {
+						return fmt.Errorf("keys %s not-equal", k)
+					}
+				}
+			case nosql.Array: // TODO
+				_, ok := decoded[k].(nosql.Array)
+				if !ok {
+					return fmt.Errorf("array not-equal %s %v %T %v %T", k, v, v, decoded[k], decoded[k])
+				}
+				for i, kv := range x {
+					if err := dcompare(
+						nosql.Document{k: decoded[k].(nosql.Array)[i]},
+						nosql.Document{k: kv},
+					); err != nil {
+						return err
+					}
+				}
+			default:
+				if decoded[k] != v {
+					return fmt.Errorf("value not-equal %s %v %T %v %T", k, v, v, decoded[k], decoded[k])
+				}
+			}
+		}
+	}
+	return nil
+}
 
 func testDB() string {
 	switch defaultDriverName {
@@ -78,6 +174,25 @@ func TestMemstore(t *testing.T) {
 	err = dbc.Close()
 	if err != nil {
 		t.Error("DB close error", err)
+	}
+}
+
+func TestIntStr(t *testing.T) {
+	testI := []int64{120000, -4, 88, 0, -7000000, 88, math.MaxInt64, math.MinInt64}
+	testS := []string{}
+	for _, v := range testI {
+		testS = append(testS, itos(v))
+	}
+	//t.Log(testS)
+	sort.Strings(testS)
+	//t.Log(testS)
+	sort.Slice(testI, func(i, j int) bool { return testI[i] < testI[j] })
+	for k, v := range testS {
+		r := stoi(v)
+		//t.Logf("Sort of stringed int64: %v %v %v", k, r, testI[k])
+		if r != testI[k] {
+			t.Errorf("Sorting of stringed int64s wrong: %v %v %v", k, r, testI[k])
+		}
 	}
 }
 

--- a/graph/nosql/ouch/ouch_test.go
+++ b/graph/nosql/ouch/ouch_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"testing"
+	"time"
 
 	_ "github.com/go-kivik/memorydb"
 	"github.com/stretchr/testify/require"
@@ -44,6 +45,21 @@ func xTestOuchAll(t *testing.T) {
 	})
 }
 
+var allsorts = nosql.Document{
+	"Vnil": nil,
+	"VDocument": nosql.Document{
+		"Velement": nosql.String("test"),
+	},
+	"VArray":  nosql.Array{nosql.String("A"), nosql.String("B"), nosql.String("C")},
+	"VKey":    nosql.Key{"1", "2", "3"},
+	"VString": nosql.String("TEST"),
+	"VInt":    nosql.Int(42),
+	"VFloat":  nosql.Float(42.42),
+	"VBool":   nosql.Bool(true),
+	"VTime":   nosql.Time(time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)),
+	"VBytes":  nosql.Bytes{1, 2, 3, 4},
+}
+
 // TestMemstore does those tests possible using the memory backend (simple only)
 func TestMemstore(t *testing.T) {
 	defaultDriverName = "memory" // for testing only
@@ -51,6 +67,13 @@ func TestMemstore(t *testing.T) {
 	if err != nil {
 		t.Error("DB create error", defaultDriverName, dbc, err)
 		return
+	}
+	key, err := dbc.Insert("test", nil, allsorts)
+	if err != nil {
+		t.Error("insert error", err)
+	}
+	if err := dbc.(*DB).dcheck(key, allsorts); err != nil {
+		t.Error(err)
 	}
 	err = dbc.Close()
 	if err != nil {

--- a/graph/nosql/ouch/values.go
+++ b/graph/nosql/ouch/values.go
@@ -1,0 +1,163 @@
+package ouch
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/cayleygraph/cayley/graph/nosql"
+)
+
+const (
+	int64Adjust  = 1 << 63
+	keySeparator = "|"
+	timeFormat   = time.RFC3339
+)
+
+// itos serializes int64 into a sortable string 13 chars long.
+// NOTE: in JS there are no native 64bit integers.
+func itos(i int64) string {
+	s := strconv.FormatUint(uint64(i)+int64Adjust, 32)
+	const z = "0000000000000"
+	return z[len(s):] + s
+}
+
+// stoi de-serializes int64 from a sortable string 13 chars long.
+func stoi(s string) int64 {
+	ret, err := strconv.ParseUint(s, 32, 64)
+	if err != nil {
+		//TODO handle error?
+		return 0
+	}
+	return int64(ret - int64Adjust)
+}
+
+// toInterfaceValue serializes nosql.Value -> native json values.
+func toInterfaceValue(k string, v nosql.Value) interface{} {
+	switch v := v.(type) {
+	case nil:
+		return nil
+	case nosql.Document:
+		return toInterfaceDoc(v)
+	case nosql.Array: // TODO this encoding of array may be problematic, as we've lost the type info
+		arr := make([]interface{}, 0, len(v))
+		for _, s := range v {
+			arr = append(arr, toInterfaceValue(k, s))
+		}
+		return arr
+	case nosql.Key: // special handling here, as type can't be inferred from json
+		return "K" + strings.Join(v, keySeparator)
+	case nosql.String:
+		if k[0] == '_' {
+			return string(v)
+		}
+		return "S" + string(v)
+	case nosql.Int: // special handling here, as type can't be inferred from json
+		return "I" + itos(int64(v))
+	case nosql.Float:
+		return v
+	case nosql.Bool:
+		return v
+	case nosql.Time: // special handling here, as type can't be inferred from json
+		return "T" + time.Time(v).Format(timeFormat)
+	case nosql.Bytes: // special handling here, as type can't be inferred from json
+		return "B" + base64.StdEncoding.EncodeToString(v)
+	default:
+		panic(fmt.Errorf("unsupported type: %T", v))
+	}
+}
+
+func toInterfaceDoc(d nosql.Document) map[string]interface{} {
+	if d == nil {
+		return nil
+	}
+	m := make(map[string]interface{})
+	for k, v := range d {
+		m[k] = toInterfaceValue(k, v)
+	}
+	return m
+}
+
+func fromInterfaceValue(k string, v interface{}) nosql.Value {
+	switch v := v.(type) {
+	case nil:
+		return nil
+	case map[string]interface{}:
+		return fromInterfaceDoc(v)
+	case []interface{}:
+		arr := make(nosql.Array, 0, len(v))
+		for _, s := range v {
+			arr = append(arr, fromInterfaceValue(k, s))
+		}
+		return arr
+	case string:
+		if len(v) == 0 {
+			return nosql.String("")
+		}
+		if k[0] == '_' {
+			return nosql.String(v)
+		}
+		typ := v[0]
+		v = v[1:]
+		switch typ {
+		case 'S':
+			return nosql.String(v)
+
+		case 'K':
+			key := make(nosql.Key, 0, len(v))
+			for _, part := range strings.Split(v, keySeparator) {
+				key = append(key, part)
+			}
+			return key
+
+		case 'B':
+			byts, err := base64.StdEncoding.DecodeString(v)
+			if err != nil {
+				// TODO consider how to handle this error properly
+				return nosql.Bytes(nil)
+			}
+			return nosql.Bytes(byts)
+
+		case 'T':
+			tim, err := time.Parse(timeFormat, v)
+			if err != nil {
+				// TODO consider how to handle this error properly
+				return nosql.Time(tim)
+			}
+			return nosql.Time(tim)
+
+		case 'I':
+			return nosql.Int(stoi(v))
+
+		default:
+			panic(fmt.Errorf("unsupported serialized type: %v", v))
+		}
+	case int:
+		return nosql.Int(v)
+	case int64:
+		return nosql.Int(v)
+	case float64:
+		return nosql.Float(v)
+	case bool:
+		return nosql.Bool(v)
+	case time.Time:
+		return nosql.Time(v)
+	case []byte:
+		return nosql.Bytes(v)
+	default:
+		panic(fmt.Errorf("unsupported type: %T", v))
+	}
+}
+
+func fromInterfaceDoc(d map[string]interface{}) nosql.Document {
+	if d == nil {
+		return nil
+	}
+	m := make(nosql.Document, len(d))
+	for k, v := range d {
+		m[k] = fromInterfaceValue(k, v)
+	}
+	return m
+}

--- a/graph/nosql/quadstore.go
+++ b/graph/nosql/quadstore.go
@@ -1,0 +1,556 @@
+// Copyright 2014 The Cayley Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nosql
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/cayleygraph/cayley/clog"
+	"github.com/cayleygraph/cayley/graph"
+	"github.com/cayleygraph/cayley/graph/iterator"
+	"github.com/cayleygraph/cayley/internal/lru"
+	"github.com/cayleygraph/cayley/quad"
+	"github.com/cayleygraph/cayley/quad/pquads"
+)
+
+const DefaultDBName = "cayley"
+
+type Registration struct {
+	NewFunc      NewFunc
+	InitFunc     InitFunc
+	IsPersistent bool
+}
+
+type InitFunc func(string, graph.Options) (Database, error)
+type NewFunc func(string, graph.Options) (Database, error)
+
+func Register(name string, r Registration) {
+	graph.RegisterQuadStore(name, graph.QuadStoreRegistration{
+		InitFunc: func(addr string, opt graph.Options) error {
+			if !r.IsPersistent {
+				return nil
+			}
+			db, err := r.InitFunc(addr, opt)
+			if err != nil {
+				return err
+			}
+			defer db.Close()
+			if err = Init(db, opt); err != nil {
+				return err
+			}
+			return db.Close()
+		},
+		NewFunc: func(addr string, opt graph.Options) (graph.QuadStore, error) {
+			db, err := r.NewFunc(addr, opt)
+			if err != nil {
+				return nil, err
+			}
+			if !r.IsPersistent {
+				if err = Init(db, opt); err != nil {
+					db.Close()
+					return nil, err
+				}
+			}
+			return New(db, opt)
+		},
+		IsPersistent: r.IsPersistent,
+	})
+}
+
+func Init(db Database, opt graph.Options) error {
+	return ensureIndexes(db)
+}
+
+func New(db Database, opt graph.Options) (graph.QuadStore, error) {
+	if err := ensureIndexes(db); err != nil {
+		return nil, err
+	}
+	qs := &QuadStore{
+		db:    db,
+		ids:   lru.New(1 << 16),
+		sizes: lru.New(1 << 16),
+	}
+	return qs, nil
+}
+
+type NodeHash string
+
+func (NodeHash) IsNode() bool       { return false }
+func (v NodeHash) Key() interface{} { return v }
+
+type QuadHash string
+
+func (QuadHash) IsNode() bool       { return false }
+func (v QuadHash) Key() interface{} { return v }
+
+func (h QuadHash) Get(d quad.Direction) string {
+	var offset int
+	switch d {
+	case quad.Subject:
+		offset = 0
+	case quad.Predicate:
+		offset = (quad.HashSize * 2)
+	case quad.Object:
+		offset = (quad.HashSize * 2) * 2
+	case quad.Label:
+		offset = (quad.HashSize * 2) * 3
+		if len(h) == offset { // no label
+			return ""
+		}
+	}
+	return string(h[offset : quad.HashSize*2+offset])
+}
+
+const (
+	colLog   = "log"
+	colNodes = "nodes"
+	colQuads = "quads"
+
+	fldSubject   = "subject"
+	fldPredicate = "predicate"
+	fldObject    = "object"
+	fldLabel     = "label"
+
+	fldValue   = "Name"
+	fldSize    = "Size"
+	fldAdded   = "Added"
+	fldDeleted = "Deleted"
+
+	fldValData = "val"
+	fldIRI     = "iri"
+	fldBNode   = "bnode"
+	fldType    = "type"
+	fldLang    = "lang"
+)
+
+type QuadStore struct {
+	db    Database
+	ids   *lru.Cache
+	sizes *lru.Cache
+}
+
+func ensureIndexes(db Database) error {
+	err := db.EnsureIndex(colLog)
+	if err != nil {
+		return err
+	}
+	err = db.EnsureIndex(colNodes)
+	if err != nil {
+		return err
+	}
+	err = db.EnsureIndex(colQuads,
+		Index{Field: fldSubject, Type: StringExact},
+		Index{Field: fldPredicate, Type: StringExact},
+		Index{Field: fldObject, Type: StringExact},
+		Index{Field: fldLabel, Type: StringExact},
+	)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (qs *QuadStore) getIDForQuad(t quad.Quad) string {
+	id := hashOf(t.Subject)
+	id += hashOf(t.Predicate)
+	id += hashOf(t.Object)
+	id += hashOf(t.Label)
+	return id
+}
+
+func hashOf(s quad.Value) string {
+	if s == nil {
+		return ""
+	}
+	return hex.EncodeToString(quad.HashOf(s))
+}
+
+type node struct {
+	ID   string   `json:"id"`
+	Name Document `json:"Name"`
+	Size int      `json:"Size"`
+}
+
+type logEntry struct {
+	ID     string `json:"id"`
+	Action string `json:"Action"`
+	Key    string `json:"Key"`
+}
+
+func (qs *QuadStore) updateNodeBy(ctx context.Context, name quad.Value, inc int) error {
+	_ = node{}
+	node := qs.ValueOf(name)
+	id := string(node.(NodeHash))
+
+	err := qs.db.Update(colNodes, id).Upsert(Document{
+		fldValue: toDocumentValue(name),
+	}).Inc(fldSize, inc).Do(ctx)
+	if err != nil {
+		clog.Errorf("Error updating node: %v", err)
+	}
+	if inc < 0 {
+		err = qs.db.Delete(colNodes).IDs(id).WithFields(FieldFilter{
+			Path:   []string{fldSize},
+			Filter: Equal,
+			Value:  Int(0),
+		}).Do(ctx)
+		if err != nil {
+			clog.Errorf("Error deleting empty node: %v", err)
+		}
+	}
+	return err
+}
+
+func (qs *QuadStore) updateQuad(ctx context.Context, q quad.Quad, id string, proc graph.Procedure) error {
+	var setname string
+	if proc == graph.Add {
+		setname = fldAdded
+	} else if proc == graph.Delete {
+		setname = fldDeleted
+	}
+	doc := Document{
+		fldSubject:   String(hashOf(q.Subject)),
+		fldPredicate: String(hashOf(q.Predicate)),
+		fldObject:    String(hashOf(q.Object)),
+	}
+	if l := hashOf(q.Label); l != "" {
+		doc[fldLabel] = String(l)
+	}
+	err := qs.db.Update(colQuads, qs.getIDForQuad(q)).Upsert(doc).
+		Push(setname, String(id)).Do(ctx)
+	if err != nil {
+		clog.Errorf("Error: %v", err)
+	}
+	return err
+}
+
+func checkQuadValid(q Document) bool {
+	added, _ := q[fldAdded].(Array)
+	deleted, _ := q[fldDeleted].(Array)
+	return len(added) > len(deleted)
+}
+
+func (qs *QuadStore) checkValid(key string) bool {
+	q, err := qs.db.FindByID(colQuads, key)
+	if err == ErrNotFound {
+		return false
+	}
+	if err != nil {
+		clog.Errorf("Other error checking valid quad: %s %v.", key, err)
+		return false
+	}
+	return checkQuadValid(q)
+}
+
+func (qs *QuadStore) updateLog(d *graph.Delta) (string, error) {
+	var action string
+	if d.Action == graph.Add {
+		action = "Add"
+	} else {
+		action = "Delete"
+	}
+	_ = logEntry{}
+	return qs.db.Insert(colLog, "", Document{
+		"Action": String(action),
+		"Key":    String(qs.getIDForQuad(d.Quad)),
+	})
+}
+
+func (qs *QuadStore) ApplyDeltas(deltas []graph.Delta, ignoreOpts graph.IgnoreOpts) error {
+	ctx := context.TODO()
+	ids := make(map[quad.Value]int)
+	// Pre-check the existence condition.
+	for _, d := range deltas {
+		if d.Action != graph.Add && d.Action != graph.Delete {
+			return &graph.DeltaError{Delta: d, Err: graph.ErrInvalidAction}
+		}
+		key := qs.getIDForQuad(d.Quad)
+		switch d.Action {
+		case graph.Add:
+			if qs.checkValid(key) {
+				if ignoreOpts.IgnoreDup {
+					continue
+				} else {
+					return &graph.DeltaError{Delta: d, Err: graph.ErrQuadExists}
+				}
+			}
+		case graph.Delete:
+			if !qs.checkValid(key) {
+				if ignoreOpts.IgnoreMissing {
+					continue
+				} else {
+					return &graph.DeltaError{Delta: d, Err: graph.ErrQuadNotExist}
+				}
+			}
+		}
+		var dn int
+		if d.Action == graph.Add {
+			dn = 1
+		} else {
+			dn = -1
+		}
+		ids[d.Quad.Subject] += dn
+		ids[d.Quad.Object] += dn
+		ids[d.Quad.Predicate] += dn
+		if d.Quad.Label != nil {
+			ids[d.Quad.Label] += dn
+		}
+	}
+	if clog.V(2) {
+		clog.Infof("Existence verified. Proceeding.")
+	}
+	oids := make([]string, 0, len(deltas))
+	for i, d := range deltas {
+		id, err := qs.updateLog(&deltas[i])
+		if err != nil {
+			return &graph.DeltaError{Delta: d, Err: err}
+		}
+		oids = append(oids, id)
+	}
+	// make sure to create all nodes before writing any quads
+	// concurrent reads may observe broken quads in other case
+	for k, v := range ids {
+		err := qs.updateNodeBy(ctx, k, v)
+		if err != nil {
+			return err
+		}
+	}
+	for i, d := range deltas {
+		err := qs.updateQuad(ctx, d.Quad, oids[i], d.Action)
+		if err != nil {
+			return &graph.DeltaError{Delta: d, Err: err}
+		}
+	}
+	return nil
+}
+
+type nodeValue struct {
+	Value   string `json:"val"`
+	IsIRI   bool   `json:"iri,omitempty"`
+	IsBNode bool   `json:"bnode,omitempty"`
+	Type    string `json:"type,omitempty"`
+	Lang    string `json:"lang,omitempty"`
+}
+
+func toDocumentValue(v quad.Value) Value {
+	if v == nil {
+		return nil
+	}
+	_ = nodeValue{}
+	switch d := v.(type) {
+	case quad.Raw:
+		return String(d) // compatibility
+	case quad.String:
+		return Document{fldValData: String(d)}
+	case quad.IRI:
+		return Document{fldValData: String(d), fldIRI: Bool(true)}
+	case quad.BNode:
+		return Document{fldValData: String(d), fldBNode: Bool(true)}
+	case quad.TypedString:
+		return Document{fldValData: String(d.Value), fldType: String(d.Type)}
+	case quad.LangString:
+		return Document{fldValData: String(d.Value), fldLang: String(d.Lang)}
+	case quad.Int:
+		return Int(d)
+	case quad.Float:
+		return Float(d)
+	case quad.Bool:
+		return Bool(d)
+	case quad.Time:
+		return Time(d)
+	default:
+		qv := pquads.MakeValue(v)
+		data, err := qv.Marshal()
+		if err != nil {
+			panic(err)
+		}
+		return Bytes(data)
+	}
+}
+
+func toQuadValue(v Value) quad.Value {
+	if v == nil {
+		return nil
+	}
+	_ = nodeValue{}
+	switch d := v.(type) {
+	case String:
+		return quad.Raw(d) // compatibility
+	case Int:
+		return quad.Int(d)
+	case Float:
+		return quad.Float(d)
+	case Bool:
+		return quad.Bool(d)
+	case Time:
+		return quad.Time(d)
+	case Document: // TODO(dennwc): use raw document instead?
+		s, ok := d[fldValData].(String)
+		if !ok {
+			clog.Errorf("Error: Empty value in map: %v", v)
+			return nil
+		}
+		if len(d) == 1 {
+			return quad.String(s)
+		}
+		if o, ok := d[fldIRI].(Bool); ok && bool(o) {
+			return quad.IRI(s)
+		} else if o, ok := d[fldBNode].(Bool); ok && bool(o) {
+			return quad.BNode(s)
+		} else if o, ok := d[fldLang].(String); ok && o != "" {
+			return quad.LangString{
+				Value: quad.String(s),
+				Lang:  string(o),
+			}
+		} else if o, ok := d[fldType].(String); ok && o != "" {
+			return quad.TypedString{
+				Value: quad.String(s),
+				Type:  quad.IRI(string(o)),
+			}
+		}
+		return quad.String(s)
+	case Bytes:
+		var p pquads.Value
+		if err := p.Unmarshal(d); err != nil {
+			clog.Errorf("Error: Couldn't decode value: %v", err)
+			return nil
+		}
+		return p.ToNative()
+	default:
+		panic(fmt.Errorf("unsupported type: %T", v))
+	}
+}
+
+func (qs *QuadStore) Quad(val graph.Value) quad.Quad {
+	h := val.(QuadHash)
+	return quad.Quad{
+		Subject:   qs.NameOf(NodeHash(h.Get(quad.Subject))),
+		Predicate: qs.NameOf(NodeHash(h.Get(quad.Predicate))),
+		Object:    qs.NameOf(NodeHash(h.Get(quad.Object))),
+		Label:     qs.NameOf(NodeHash(h.Get(quad.Label))),
+	}
+}
+
+func (qs *QuadStore) QuadIterator(d quad.Direction, val graph.Value) graph.Iterator {
+	return NewIterator(qs, "quads", d, val)
+}
+
+func (qs *QuadStore) NodesAllIterator() graph.Iterator {
+	return NewAllIterator(qs, "nodes")
+}
+
+func (qs *QuadStore) QuadsAllIterator() graph.Iterator {
+	return NewAllIterator(qs, "quads")
+}
+
+func (qs *QuadStore) ValueOf(s quad.Value) graph.Value {
+	return NodeHash(hashOf(s))
+}
+
+func (qs *QuadStore) NameOf(v graph.Value) quad.Value {
+	if v == nil {
+		return nil
+	} else if v, ok := v.(graph.PreFetchedValue); ok {
+		return v.NameOf()
+	}
+	hash := v.(NodeHash)
+	if hash == "" {
+		return nil
+	}
+	if val, ok := qs.ids.Get(string(hash)); ok {
+		return val.(quad.Value)
+	}
+	_ = node{}
+	nd, err := qs.db.FindByID(colNodes, string(hash))
+	if err != nil {
+		clog.Errorf("Error: Couldn't retrieve node %s %v", v, err)
+	}
+	id, _ := nd[IDField].(String)
+	dv, _ := nd[fldValue]
+	qv := toQuadValue(dv)
+	if id != "" && qv != nil {
+		qs.ids.Put(string(hash), qv)
+	}
+	return qv
+}
+
+func (qs *QuadStore) Size() int64 {
+	// TODO(barakmich): Make size real; store it in the log, and retrieve it.
+	count, err := qs.db.Query(colQuads).Count(context.TODO())
+	if err != nil {
+		clog.Errorf("%v", err)
+		return 0
+	}
+	return count
+}
+
+func (qs *QuadStore) Horizon() graph.PrimaryKey {
+	// FIXME: this picks a random record; we need to sort at least on timestamp,
+	// or emulate a global counter and use it as an id for log entries
+	log, err := qs.db.Query(colLog).One(context.TODO())
+	if err != nil {
+		if err == ErrNotFound {
+			return graph.NewSequentialKey(0)
+		}
+		clog.Errorf("could not get horizon: %v", err)
+	}
+	_ = logEntry{}
+	var id string
+	if v, ok := log[IDField].(String); ok {
+		id = string(v)
+	}
+	if id == "" {
+		return graph.PrimaryKey{}
+	}
+	return graph.NewUniqueKey(id)
+}
+
+func (qs *QuadStore) FixedIterator() graph.FixedIterator {
+	return iterator.NewFixed(iterator.Identity)
+}
+
+func (qs *QuadStore) Close() error {
+	return qs.db.Close()
+}
+
+func (qs *QuadStore) QuadDirection(in graph.Value, d quad.Direction) graph.Value {
+	return NodeHash(in.(QuadHash).Get(d))
+}
+
+// TODO(barakmich): Rewrite bulk loader. For now, iterating around blocks is the way we'll go about it.
+
+func (qs *QuadStore) getSize(col string, constraints []FieldFilter) (int64, error) {
+	cacheKey := ""
+	for _, c := range constraints { // FIXME
+		cacheKey += fmt.Sprint(c.Path, c.Filter, c.Value)
+	}
+	key := col + cacheKey
+	if val, ok := qs.sizes.Get(key); ok {
+		return val.(int64), nil
+	}
+	q := qs.db.Query(col)
+	if len(constraints) != 0 {
+		q = q.WithFields(constraints...)
+	}
+	size, err := q.Count(context.TODO())
+	if err != nil {
+		clog.Errorf("error getting size for iterator: %v", err)
+		return -1, err
+	}
+	qs.sizes.Put(key, int64(size))
+	return int64(size), nil
+}

--- a/graph/nosql/quadstore.go
+++ b/graph/nosql/quadstore.go
@@ -219,7 +219,7 @@ func (qs *QuadStore) updateNodeBy(ctx context.Context, name quad.Value, inc int)
 		clog.Errorf("Error updating node: %v", err)
 	}
 	if inc < 0 {
-		err = qs.db.Delete(colNodes).IDs(key).WithFields(FieldFilter{
+		err = qs.db.Delete(colNodes).Keys(key).WithFields(FieldFilter{
 			Path:   []string{fldSize},
 			Filter: Equal,
 			Value:  Int(0),

--- a/graph/nosql/quadstore_iterator_optimize.go
+++ b/graph/nosql/quadstore_iterator_optimize.go
@@ -1,0 +1,191 @@
+// Copyright 2014 The Cayley Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nosql
+
+import (
+	"github.com/cayleygraph/cayley/graph"
+	"github.com/cayleygraph/cayley/graph/iterator"
+	"github.com/cayleygraph/cayley/quad"
+)
+
+func (qs *QuadStore) OptimizeIterator(it graph.Iterator) (graph.Iterator, bool) {
+	switch it.Type() {
+	case graph.LinksTo:
+		return qs.optimizeLinksTo(it.(*iterator.LinksTo))
+	//case graph.And:
+	//	return qs.optimizeAndIterator(it.(*iterator.And))
+	case graph.Comparison:
+		return qs.optimizeComparison(it.(*iterator.Comparison))
+	}
+	return it, false
+}
+
+//func (qs *QuadStore) optimizeAndIterator(it *iterator.And) (graph.Iterator, bool) {
+//	// Fail fast if nothing can happen
+//	if clog.V(4) {
+//		clog.Infof("Entering optimizeAndIterator %v", it.UID())
+//	}
+//	found := false
+//	for _, it := range it.SubIterators() {
+//		if clog.V(4) {
+//			clog.Infof("%v", it.Type())
+//		}
+//		if _, ok := it.(*Iterator); ok {
+//			found = true
+//		}
+//	}
+//	if !found {
+//		if clog.V(4) {
+//			clog.Infof("Aborting optimizeAndIterator")
+//		}
+//		return it, false
+//	}
+//
+//	newAnd := iterator.NewAnd(qs)
+//	var mongoIt *Iterator
+//	for _, it := range it.SubIterators() {
+//		if sit, ok := it.(*Iterator); ok {
+//			if mongoIt == nil {
+//				mongoIt = sit
+//			} else {
+//				newAnd.AddSubIterator(it)
+//			}
+//			continue
+//		}
+//		switch it.Type() {
+//		case graph.LinksTo:
+//			continue
+//		default:
+//			newAnd.AddSubIterator(it)
+//		}
+//	}
+//	stats := mongoIt.Stats()
+//
+//	lset := []graph.Linkage{
+//		{
+//			Dir:   mongoIt.dir,
+//			Value: mongoIt.hash,
+//		},
+//	}
+//
+//	n := 0
+//	for _, it := range it.SubIterators() {
+//		if it.Type() == graph.LinksTo {
+//			lto := it.(*iterator.LinksTo)
+//			// Is it more effective to do the replacement, or let the mongo check the linksto?
+//			ltostats := lto.Stats()
+//			if (ltostats.ContainsCost+stats.NextCost)*stats.Size > (ltostats.NextCost+stats.ContainsCost)*ltostats.Size {
+//				continue
+//			}
+//			newLto := NewLinksTo(qs, lto.SubIterators()[0], "quads", lto.Direction(), lset)
+//			newAnd.AddSubIterator(newLto)
+//			n++
+//		}
+//	}
+//	if n == 0 {
+//		return it, false
+//	}
+//
+//	return newAnd.Optimize()
+//}
+
+func (qs *QuadStore) optimizeLinksTo(it *iterator.LinksTo) (graph.Iterator, bool) {
+	subs := it.SubIterators()
+	if len(subs) != 1 {
+		return it, false
+	}
+	primary := subs[0]
+	if primary.Type() == graph.Fixed {
+		size, _ := primary.Size()
+		if size == 1 {
+			if !primary.Next() {
+				panic("unexpected size during optimize")
+			}
+			val := primary.Result()
+			newIt := qs.QuadIterator(it.Direction(), val)
+			nt := newIt.Tagger()
+			nt.CopyFrom(it)
+			for _, tag := range primary.Tagger().Tags() {
+				nt.AddFixed(tag, val)
+			}
+			it.Close()
+			return newIt, true
+		}
+	}
+	return it, false
+}
+
+func (qs *QuadStore) optimizeComparison(it *iterator.Comparison) (graph.Iterator, bool) {
+	subs := it.SubIterators()
+	if len(subs) != 1 {
+		return it, false
+	}
+	mit, ok := subs[0].(*Iterator)
+	if !ok || !mit.isAll {
+		return it, false
+	}
+	var filter Filter
+	switch it.Operator() {
+	case iterator.CompareGT:
+		filter = GT
+	case iterator.CompareGTE:
+		filter = GTE
+	case iterator.CompareLT:
+		filter = LT
+	case iterator.CompareLTE:
+		filter = LTE
+	default:
+		return it, false
+	}
+	const base = fldValue
+	fieldPath := func(s string) []string {
+		return []string{fldValue, s}
+	}
+
+	var constraints []FieldFilter
+	switch v := it.Value().(type) {
+	case quad.String:
+		constraints = []FieldFilter{
+			{Path: fieldPath(fldValData), Filter: filter, Value: String(v)},
+			{Path: fieldPath(fldIRI), Filter: NotEqual, Value: Bool(true)},
+			{Path: fieldPath(fldBNode), Filter: NotEqual, Value: Bool(true)},
+		}
+	case quad.IRI:
+		constraints = []FieldFilter{
+			{Path: fieldPath(fldValData), Filter: filter, Value: String(v)},
+			{Path: fieldPath(fldIRI), Filter: Equal, Value: Bool(true)},
+		}
+	case quad.BNode:
+		constraints = []FieldFilter{
+			{Path: fieldPath(fldValData), Filter: filter, Value: String(v)},
+			{Path: fieldPath(fldBNode), Filter: Equal, Value: Bool(true)},
+		}
+	case quad.Int:
+		constraints = []FieldFilter{
+			{Path: []string{base}, Filter: filter, Value: Int(v)},
+		}
+	case quad.Float:
+		constraints = []FieldFilter{
+			{Path: []string{base}, Filter: filter, Value: Float(v)},
+		}
+	case quad.Time:
+		constraints = []FieldFilter{
+			{Path: []string{base}, Filter: filter, Value: Time(v)},
+		}
+	default:
+		return it, false
+	}
+	return NewIteratorWithConstraints(qs, mit.collection, constraints), true
+}


### PR DESCRIPTION
@dennwc - This PR is to let you know that I'm making some progress with the driver we discussed at https://discourse.cayley.io/t/running-cayley-in-the-browser/960/14

Go/CouchDB runs nosqltest.TestAll() with 8 reported errors (see below).

GopherJS/PouchDB (both locally and remoting to CouchDB) have made less progress, with only a trivial hacked-together TestInsertDelete() passing so far.

I've not set the tests up to use Docker yet, please see README.md for my test setup.

The code is a bit of a mess just now with all my debug guff, and few comments ... but I think there is enough to illustrate what I've been up to over the last week or so.

Obviously happy to have feedback if you (or anyone else) feels moved to give it.

Also hope that this PR thread will allow me to ask questions when I need to.

```
Elliotts-MacBook-Pro15:ouch elliott$ go test
2017/12/02 18:02:27 ERROR: Error: Couldn't retrieve node 84b4ece65dc68422fd694583630ab8b87bc179a9 not found
2017/12/02 18:02:27 ERROR: Error: Couldn't retrieve node 84b4ece65dc68422fd694583630ab8b87bc179a9 not found
--- FAIL: TestOuchAll (11.78s)
        ouch_test.go:208: Testing against: http://testusername:testpassword@127.0.0.1:5984/ouchtest
    --- FAIL: TestOuchAll/qs (8.78s)
        --- FAIL: TestOuchAll/qs/horizon_int (0.94s)
        Error Trace:    graphtest.go:264
        Error:          Not equal:
                        expected: 11
                        actual: 0
        Messages:       Unexpected horizon value
        --- FAIL: TestOuchAll/qs/iterator (1.01s)
        Error Trace:    graphtest.go:328
        Error:          Not equal:
                        expected: []string{"A", "B", "C", "D", "E", "F", "G", "cool", "follows", "status", "status_graph"}
                        actual: []string{"", "", "", "", "", "", "", "", "", "", ""}

                        Diff:
                        --- Expected
                        +++ Actual
                        @@ -1,13 +1,13 @@
                         ([]string) (len=11) {
                        - (string) (len=1) "A",
                        - (string) (len=1) "B",
                        - (string) (len=1) "C",
                        - (string) (len=1) "D",
                        - (string) (len=1) "E",
                        - (string) (len=1) "F",
                        - (string) (len=1) "G",
                        - (string) (len=4) "cool",
                        - (string) (len=7) "follows",
                        - (string) (len=6) "status",
                        - (string) (len=12) "status_graph"
                        + (string) "",
                        + (string) "",
                        + (string) "",
                        + (string) "",
                        + (string) "",
                        + (string) "",
                        + (string) "",
                        + (string) "",
                        + (string) "",
                        + (string) "",
                        + (string) ""
                         }
        Messages:       Unexpected iterated result on repeat 0
        --- FAIL: TestOuchAll/qs/hasa (0.96s)
        Error Trace:    graphtest.go:162
                        graphtest.go:392
        Error:          Not equal:
                        expected: 11
                        actual: 0
        Messages:       [follows follows follows follows follows follows follows follows status status status]
                        vs
                        []
        --- FAIL: TestOuchAll/qs/load_typed_quad (0.81s)
        Error Trace:    graphtest.go:594
        Error:          Should be true
        Messages:       Failed to roundtrip "\"2017-12-02T18:02:20Z\"^^<schema:DateTime>" (quad.Time), got "\"2017-12-02T18:02:20Z\"^^<schema:DateTime>" (quad.Time)
        --- FAIL: TestOuchAll/qs/add_and_remove (0.93s)
        Error Trace:    graphtest.go:155
                        graphtest.go:648
        Error:          Not equal:
                        expected: []string{"A", "B", "C", "D", "E", "F", "G", "cool", "follows", "status", "status_graph"}
                        actual: []string{"", "", "", "", "", "", "", "", "", "", ""}

                        Diff:
                        --- Expected
                        +++ Actual
                        @@ -1,13 +1,13 @@
                         ([]string) (len=11) {
                        - (string) (len=1) "A",
                        - (string) (len=1) "B",
                        - (string) (len=1) "C",
                        - (string) (len=1) "D",
                        - (string) (len=1) "E",
                        - (string) (len=1) "F",
                        - (string) (len=1) "G",
                        - (string) (len=4) "cool",
                        - (string) (len=7) "follows",
                        - (string) (len=6) "status",
                        - (string) (len=12) "status_graph"
                        + (string) "",
                        + (string) "",
                        + (string) "",
                        + (string) "",
                        + (string) "",
                        + (string) "",
                        + (string) "",
                        + (string) "",
                        + (string) "",
                        + (string) "",
                        + (string) ""
                         }
        --- FAIL: TestOuchAll/qs/compare_typed_values (0.90s)
        Error Trace:    graphtest.go:162
                        graphtest.go:848
        Error:          Not equal:
                        expected: 1
                        actual: 0
        Messages:       [_:alice]
                        vs
                        []
    --- FAIL: TestOuchAll/paths (2.98s)
        --- FAIL: TestOuchAll/paths/implicit_All (0.00s)
                pathtest.go:422: got: [](0) expected: ["cool_person" "smart_person" <alice> <are> <bob> <charlie> <dani> <emily> <follows> <fred> <greg> <predicates> <smart_graph> <status>](14)
        --- FAIL: TestOuchAll/paths/implicit_All_(unoptimized) (0.00s)
                pathtest.go:422: got: [](0) expected: ["cool_person" "smart_person" <alice> <are> <bob> <charlie> <dani> <emily> <follows> <fred> <greg> <predicates> <smart_graph> <status>](14)
FAIL
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dennwc/cayley/3)
<!-- Reviewable:end -->
